### PR TITLE
fix: Update GamepadsDarwinPlugin.swift to conditionally reference sfSymbolsName

### DIFF
--- a/packages/gamepads_darwin/macos/Classes/GamepadsDarwinPlugin.swift
+++ b/packages/gamepads_darwin/macos/Classes/GamepadsDarwinPlugin.swift
@@ -42,15 +42,34 @@ public class GamepadsDarwinPlugin: NSObject, FlutterPlugin {
     }
 
     private func getValues(element: GCControllerElement) -> [(String, Float)] {
-        let name = getNameForElement(element: element)
         if let element = element as? GCControllerButtonInput {
-            return [(name ?? "Unknown button", element.value)]
+            var button: String = "Unknown button"
+            if #available(macOS 11.0, *) {
+                if (element.sfSymbolsName != nil) {
+                    button = element.sfSymbolsName!
+                }
+            }
+            
+            return [(button, element.value)]
         } else if let element = element as? GCControllerAxisInput {
-            return [(name ?? "Unknown axis", element.value)]
+            var axis: String = "Unknown axis"
+            if #available(macOS 11.0, *) {
+                if (element.sfSymbolsName != nil) {
+                    axis = element.sfSymbolsName!
+                }
+            }
+            return [(axis, element.value)]
         } else if let element = element as? GCControllerDirectionPad {
+            var directionPad: String = "Unknown direction pad"
+    
+            if #available(macOS 11.0, *) {
+                if (element.sfSymbolsName != nil) {
+                    directionPad = element.sfSymbolsName!
+                }
+            }
             return [
-                (maybeConcat(name, "xAxis"), element.xAxis.value),
-                (maybeConcat(name, "yAxis"), element.yAxis.value)
+                (maybeConcat(directionPad, "xAxis"), element.xAxis.value),
+                (maybeConcat(directionPad, "yAxis"), element.yAxis.value)
             ]
         } else {
             return []


### PR DESCRIPTION
As per issue #18, sfSymbolsName is only available in macOS 11.0 or newer, but the getValues method references it without use of conditional compilation. The result is that the example project cannot be compiled on macOS.

The proposed change provides a default label for each type of GCControllerElement (e.g. "Unknown button" for a button) which is then overridden by the sfSymbolsName property if it is available.