### PR TITLE
fix: Remove extendedGamepad from gamepads array on disconnect

### DIFF
--- a/packages/gamepads_darwin/macos/Classes/GamepadsListener.swift
+++ b/packages/gamepads_darwin/macos/Classes/GamepadsListener.swift
@@ -41,7 +41,7 @@ class GamepadsListener {
  
     @objc private func joystickDidDisconnect(notification: NSNotification) {
         if let controller = notification.object as? GCController {
-            gamepads.removeAll(where: { $0 == controller})
+            gamepads.removeAll(where: { $0 == controller.extendedGamepad })
         }
     }
 

--- a/packages/gamepads_ios/ios/Classes/GamepadsListener.swift
+++ b/packages/gamepads_ios/ios/Classes/GamepadsListener.swift
@@ -41,7 +41,7 @@ class GamepadsListener {
  
     @objc private func joystickDidDisconnect(notification: NSNotification) {
         if let controller = notification.object as? GCController {
-            gamepads.removeAll(where: { $0 == controller})
+            gamepads.removeAll(where: { $0 == controller.extendedGamepad })
         }
     }
 


### PR DESCRIPTION
I noticed that on macOS, if you disconnect and reconnect a gamepad, the gamepad id increases every time.

Turns out `joystickDidConnect` added the `extendedGamepad` to the `gamepads` array, while `joystickDidDisconnect` attempted to remove the `controller` (which owns the `extendedGamepad`).

This PR fixes that issue, confirmed on macOS. (I have no iOS device to test this on)

Related to #20 