### PR TITLE
feat: Added GamepadState that can be updated

### DIFF
--- a/packages/gamepads/example/lib/main.dart
+++ b/packages/gamepads/example/lib/main.dart
@@ -96,8 +96,13 @@ class _MyHomePageState extends State<MyHomePage> {
             const Text('Gamepads:'),
             if (loading)
               const CircularProgressIndicator()
-            else
-              ..._gamepads.map((e) => Text('${e.id} - ${e.name}')),
+            else ...[
+              for (final gamepad in _gamepads) ...[
+                Text('${gamepad.id} - ${gamepad.name}'),
+                Text('  Analog inputs: ${gamepad.state.analogInputs}'),
+                Text('  Button inputs: ${gamepad.state.buttonInputs}'),
+              ],
+            ],
           ],
         ),
       ),

--- a/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
@@ -5,6 +5,10 @@ import 'package:gamepads_platform_interface/api/gamepad_state.dart';
 import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
 
 /// Represents a single, currently connected joystick controller (or gamepad).
+///
+/// By calling the constructor, this object will automatically subscribe to
+/// events and update its internal [state]. To stop listening, be sure to call
+/// [dispose]. Failing to do so may result in the object leaking memory.
 class GamepadController {
   /// A unique identifier for the gamepad controller.
   ///
@@ -36,6 +40,7 @@ class GamepadController {
     return GamepadController(id: id, name: name, plugin: plugin);
   }
 
+  /// Stops listening for new inputs.
   Future<void> dispose() async {
     await _subscription?.cancel();
     _subscription = null;

--- a/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+
+import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 import 'package:gamepads_platform_interface/api/gamepad_state.dart';
 import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
 
@@ -14,12 +17,14 @@ class GamepadController {
 
   final state = GamepadState();
 
+  StreamSubscription<GamepadEvent>? _subscription;
+
   GamepadController({
     required this.id,
     required this.name,
     required GamepadsPlatformInterface plugin,
   }) {
-    plugin.eventsByGamepad(id).listen(state.update);
+    _subscription = plugin.eventsByGamepad(id).listen(state.update);
   }
 
   factory GamepadController.parse(
@@ -29,5 +34,10 @@ class GamepadController {
     final id = map['id'] as String;
     final name = map['name'] as String;
     return GamepadController(id: id, name: name, plugin: plugin);
+  }
+
+  Future<void> dispose() async {
+    await _subscription?.cancel();
+    _subscription = null;
   }
 }

--- a/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
@@ -1,3 +1,6 @@
+import 'package:gamepads_platform_interface/api/gamepad_state.dart';
+import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
+
 /// Represents a single, currently connected joystick controller (or gamepad).
 class GamepadController {
   /// A unique identifier for the gamepad controller.
@@ -9,14 +12,22 @@ class GamepadController {
   /// A user-facing, platform-dependant name for the gamepad controller.
   final String name;
 
+  final state = GamepadState();
+
   GamepadController({
     required this.id,
     required this.name,
-  });
+    required GamepadsPlatformInterface plugin,
+  }) {
+    plugin.eventsByGamepad(id).listen(state.update);
+  }
 
-  factory GamepadController.parse(Map<dynamic, dynamic> map) {
+  factory GamepadController.parse(
+    Map<dynamic, dynamic> map,
+    GamepadsPlatformInterface plugin,
+  ) {
     final id = map['id'] as String;
     final name = map['name'] as String;
-    return GamepadController(id: id, name: name);
+    return GamepadController(id: id, name: name, plugin: plugin);
   }
 }

--- a/packages/gamepads_platform_interface/lib/api/gamepad_state.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_state.dart
@@ -1,0 +1,17 @@
+import 'package:gamepads_platform_interface/api/gamepad_event.dart';
+
+class GamepadState {
+  final Map<String, double> analogInputs = {};
+  final Map<String, bool> buttonInputs = {};
+
+  void update(GamepadEvent event) {
+    switch (event.type) {
+      case KeyType.analog:
+        analogInputs[event.key] = event.value;
+        break;
+      case KeyType.button:
+        buttonInputs[event.key] = event.value == 1;
+        break;
+    }
+  }
+}

--- a/packages/gamepads_platform_interface/lib/api/gamepad_state.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_state.dart
@@ -1,9 +1,19 @@
 import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 
+/// The current state of a gamepad.
+///
+/// This class keeps mutable state and is intended to be kept up-to-date by
+/// calling [update] with the latest [GamepadEvent]. The [analogInputs] and
+/// [buttonInputs] maps correspond to [KeyType.analog] and [KeyType.button],
+/// respectively.
 class GamepadState {
+  /// Contains inputs from events where [GamepadEvent.type] is [KeyType.analog].
   final Map<String, double> analogInputs = {};
+
+  /// Contains inputs from events where [GamepadEvent.type] is [KeyType.button].
   final Map<String, bool> buttonInputs = {};
 
+  /// Updates the state based on the given event.
   void update(GamepadEvent event) {
     switch (event.type) {
       case KeyType.analog:

--- a/packages/gamepads_platform_interface/lib/gamepads_platform_interface.dart
+++ b/packages/gamepads_platform_interface/lib/gamepads_platform_interface.dart
@@ -22,5 +22,5 @@ abstract class GamepadsPlatformInterface extends PlatformInterface {
   Stream<GamepadEvent> get gamepadEventsStream;
 
   Stream<GamepadEvent> eventsByGamepad(String gamepadId) =>
-    gamepadEventsStream.where((event) => event.gamepadId == gamepadId);
+      gamepadEventsStream.where((event) => event.gamepadId == gamepadId);
 }

--- a/packages/gamepads_platform_interface/lib/gamepads_platform_interface.dart
+++ b/packages/gamepads_platform_interface/lib/gamepads_platform_interface.dart
@@ -20,4 +20,7 @@ abstract class GamepadsPlatformInterface extends PlatformInterface {
   Future<List<GamepadController>> listGamepads();
 
   Stream<GamepadEvent> get gamepadEventsStream;
+
+  Stream<GamepadEvent> eventsByGamepad(String gamepadId) =>
+    gamepadEventsStream.where((event) => event.gamepadId == gamepadId);
 }

--- a/packages/gamepads_platform_interface/lib/method_channel_gamepads_platform_interface.dart
+++ b/packages/gamepads_platform_interface/lib/method_channel_gamepads_platform_interface.dart
@@ -21,7 +21,7 @@ class MethodChannelGamepadsPlatformInterface extends GamepadsPlatformInterface {
       <String, dynamic>{},
     );
     return result!.map((Object? e) {
-      return GamepadController.parse(e! as Map<dynamic, dynamic>);
+      return GamepadController.parse(e! as Map<dynamic, dynamic>, this);
     }).toList();
   }
 


### PR DESCRIPTION
Usage: 
```dart
final gamepads = await Gamepads.listGamepads();
final gamepad = gamepads.first;

// Now, at any point, you can check gamepad
print(gamepad.state.buttonInputs);
print(gamepad.state.analogInputs);

// When you're done with the gamepad, call dispose:
await gamepad.dispose();
```

Was not able to test on Windows due to some long compiler errors (see my message [here](https://discord.com/channels/509714518008528896/1285902339450081290/1287237602235256914)) but will hopefully be able to test on Linux later this week

Fixes #12