### PR TITLE
fix: Update gamepad.cpp includes to fix windows compilation error

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -2,3 +2,4 @@
 # http://clang.llvm.org/docs/ClangFormatStyleOptions.html
 BasedOnStyle: Chromium
 Standard: c++17
+SortIncludes: false

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -1,9 +1,9 @@
 #include <iostream>
 #define WIN32_LEAN_AND_MEAN
-#include <dbt.h>
-#include <hidclass.h>
 #include <initguid.h>
 #include <windows.h>
+#include <dbt.h>
+#include <hidclass.h>
 #pragma comment(lib, "winmm.lib")
 #include <mmsystem.h>
 


### PR DESCRIPTION
Fixes: #42 

Kudos to @UltimateVision

(I haven't tried this since I only have linux boxes, so it's a bit of a shot in the dark)