### PR TITLE
fix: Use `std::optional` for return from `GamepadListenerProc`

### DIFF
--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -167,8 +167,6 @@ LRESULT CALLBACK GamepadListenerProc(HWND hwnd,
       PostQuitMessage(0);
       return 0;
     }
-    default: {
-      return DefWindowProc(hwnd, uMsg, wParam, lParam);
-    }
   }
+  return 0;
 }

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -9,7 +9,6 @@
 
 #include <list>
 #include <map>
-#include <optional>
 #include <set>
 #include <thread>
 
@@ -135,7 +134,7 @@ void Gamepads::update_gamepads() {
 
 std::set<std::wstring> connected_devices;
 
-LRESULT CALLBACK GamepadListenerProc(HWND hwnd,
+std::optional<LRESULT> CALLBACK GamepadListenerProc(HWND hwnd,
                                      UINT uMsg,
                                      WPARAM wParam,
                                      LPARAM lParam) {
@@ -168,5 +167,5 @@ LRESULT CALLBACK GamepadListenerProc(HWND hwnd,
       return 0;
     }
   }
-  return 0;
+  return std::nullopt;
 }

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -135,9 +135,9 @@ void Gamepads::update_gamepads() {
 std::set<std::wstring> connected_devices;
 
 std::optional<LRESULT> CALLBACK GamepadListenerProc(HWND hwnd,
-                                     UINT uMsg,
-                                     WPARAM wParam,
-                                     LPARAM lParam) {
+                                                    UINT uMsg,
+                                                    WPARAM wParam,
+                                                    LPARAM lParam) {
   switch (uMsg) {
     case WM_DEVICECHANGE: {
       if (lParam != NULL) {

--- a/packages/gamepads_windows/windows/gamepad.h
+++ b/packages/gamepads_windows/windows/gamepad.h
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <list>
 #include <map>
+#include <optional>
 
 struct Gamepad {
   UINT joy_id;
@@ -36,7 +37,7 @@ class Gamepads {
 
 extern Gamepads gamepads;
 
-LRESULT CALLBACK GamepadListenerProc(HWND hwnd,
+std::optional<LRESULT> CALLBACK GamepadListenerProc(HWND hwnd,
                                      UINT uMsg,
                                      WPARAM wParam,
                                      LPARAM lParam);

--- a/packages/gamepads_windows/windows/gamepad.h
+++ b/packages/gamepads_windows/windows/gamepad.h
@@ -38,6 +38,6 @@ class Gamepads {
 extern Gamepads gamepads;
 
 std::optional<LRESULT> CALLBACK GamepadListenerProc(HWND hwnd,
-                                     UINT uMsg,
-                                     WPARAM wParam,
-                                     LPARAM lParam);
+                                                    UINT uMsg,
+                                                    WPARAM wParam,
+                                                    LPARAM lParam);


### PR DESCRIPTION
I made a small mistake in the previous PR #56. This PR fixes that.