### PR TITLE
Fix bluetooth keyboard not working.

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ class MainActivity: FlutterActivity(), GamepadsCompatibleActivity {
     }
     
     override fun dispatchKeyEvent(keyEvent: KeyEvent): Boolean {
-        return keyListener?.invoke(keyEvent) ?: false
+        return keyListener?.invoke(keyEvent) ?: super.dispatchKeyEvent(keyEvent)
     }
 
     override fun registerInputDeviceListener(

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsCompatibleActivity.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsCompatibleActivity.kt
@@ -10,6 +10,8 @@ interface GamepadsCompatibleActivity {
     fun isGamepadsInputDevice(device: InputDevice): Boolean {
         return device.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
                 || device.sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
+                // Some bluetooth keyboards are identified as GamePad. Check if it is ALPHABETIC keyboard.
+                && device.keyboardType != InputDevice.KEYBOARD_TYPE_ALPHABETIC
     }
 
     fun registerInputDeviceListener(listener: InputManager.InputDeviceListener, handler: Handler?)


### PR DESCRIPTION
This pull request fixes [issue 63](https://github.com/flame-engine/gamepads/issues/63) and it should make alphabetic bluetooth keyboards work. It is cherry-picked from a custom gamepads repo so please test if it works. @spydon 