### PR TITLE
fix!: Button input value was flipped on windows

### DIFF
--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -224,7 +224,7 @@ void Gamepads::read_gamepad(GamepadData* gamepad, IGameInputDevice* device) {
     if (reading != nullptr) {
       if (reading->GetGamepadState(&state)) {
         if (are_states_different(previous_state, state)) {
-          auto events = diff_states(state, previous_state);
+          auto events = diff_states(previous_state, state);
           for (auto event : events) {
             if (event_emitter.has_value()) {
               (*event_emitter)(gamepad, event);


### PR DESCRIPTION
0.0 was emitted on press down, and then 1.0 on button up.

For axis input this also is an improvement as it now correctly uses the last input packet and not the second last one as the axis input.