### PR TITLE
fix: Remove unused dependency that causes package:js dependency

### DIFF
--- a/packages/gamepads_web/pubspec.yaml
+++ b/packages/gamepads_web/pubspec.yaml
@@ -23,7 +23,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   gamepads_platform_interface: ^0.1.3
-  js_interop: ^0.0.1
   plugin_platform_interface: ^2.1.8
   web: ^1.1.0
 


### PR DESCRIPTION
If I am not mistaken, apps that depend on package:js cannot be compiled for WASM:
https://docs.flutter.dev/platform-integration/web/wasm#js-interop-wasm

But it looks like gamepads_web only indirectly depended on package:js via an js_interop which is part of Dart and doesn't need to be depended upon via pubspec.yaml.