### PR TITLE
fix(android): Capture joystick motion via decorView listener

### DIFF
--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.InputDevice
 import android.view.KeyEvent
 import android.view.MotionEvent
+import android.view.View
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.embedding.engine.plugins.activity.ActivityAware
@@ -25,6 +26,13 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private lateinit var channel : MethodChannel
   private lateinit var devices : DeviceListener
   private lateinit var events : EventListener
+
+  // Decor view we attach an OnGenericMotionListener to, plus the listener
+  // itself, so analog motion is captured even when the focused view (e.g.
+  // FlutterView) consumes joystick MotionEvents before they bubble up to
+  // Activity.dispatchGenericMotionEvent. Kept for removal on detach.
+  private var motionDecorView: View? = null
+  private var genericMotionListener: View.OnGenericMotionListener? = null
 
   private fun listGamepads(): List<Map<String, String>>  {
     return devices.getDevices().map { device ->
@@ -77,10 +85,33 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
         false
       }
     }
+
+    // In an embedded FlutterActivity the focused view (FlutterView/
+    // FlutterSurfaceView) consumes joystick MotionEvents, so they never reach
+    // Activity.dispatchGenericMotionEvent and the handler above is never
+    // invoked for analog axes. Attaching an OnGenericMotionListener to the
+    // decor view captures them at the view layer. Duplicate emissions (if both
+    // paths fire) are de-duplicated by EventListener's per-axis threshold.
+    val listener = View.OnGenericMotionListener { _, event ->
+      if (devices.containsKey(event.deviceId)) {
+        events.onMotionEvent(event, channel)
+      } else {
+        false
+      }
+    }
+    val decorView = activity.window?.decorView
+    decorView?.setOnGenericMotionListener(listener)
+    motionDecorView = decorView
+    genericMotionListener = listener
   }
 
   override fun onDetachedFromActivity() {
-    // No-op
+    // Remove the decor-view motion listener to avoid leaking the activity.
+    if (genericMotionListener != null) {
+      motionDecorView?.setOnGenericMotionListener(null)
+    }
+    motionDecorView = null
+    genericMotionListener = null
   }
 
   override fun onDetachedFromActivityForConfigChanges() {


### PR DESCRIPTION
## Description

Fixes analog input loss in an embedded `FlutterActivity`.

On Android, generic motion events for joystick-class devices (`SOURCE_JOYSTICK`) are delivered to the **currently focused View**, not reliably up through `Activity.dispatchGenericMotionEvent`. In an embedded Flutter app the `FlutterView` / `FlutterSurfaceView` holds focus and consumes the joystick `MotionEvent` at the View level, so it never bubbles to the host `Activity`. The plugin relies solely on `GamepadsCompatibleActivity` forwarding `dispatchGenericMotionEvent`, so **all analog axes (sticks, dials, HAT/D-pad) are silently dropped** while button `KeyEvent`s work fine (they travel the separate `dispatchKeyEvent` path).

This change attaches a `View.OnGenericMotionListener` to the activity's decor view, capturing generic motion at the View layer in addition to the existing Activity path. The listener is removed in `onDetachedFromActivity` to avoid leaking the activity. If both paths fire, duplicate emissions are de-duplicated by `EventListener`'s existing per-axis threshold.

See #109 for the full layer-by-layer diagnosis (evdev OK, InputManager OK, device filter OK, `Activity.dispatchGenericMotionEvent` never called).

Fixes #109

## Type of Change

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [ ] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change

## Notes

- Affects **any** controller with analog sticks used in an embedded `FlutterActivity`; reproduced on a DJI RC Pro (the app runs directly on the controller, so the FlutterView always holds focus).
- The change is in Kotlin (`gamepads_android`); `dart format` / Dart analyzer don't apply to it.
- Verified on a DJI RC Pro: before this change `Activity.dispatchGenericMotionEvent` was never invoked for sticks; after it, `Gamepads.events` emits analog events as the sticks/dials move.
