### PR TITLE
fix(android): Migrate to built-in Kotlin for AGP 9 support

### DIFF
--- a/packages/gamepads_android/android/build.gradle
+++ b/packages/gamepads_android/android/build.gradle
@@ -22,7 +22,12 @@ allprojects {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+
+if (agpMajor < 9) {
+    apply plugin: 'kotlin-android'
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -34,10 +39,6 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_8
         targetCompatibility JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = '1.8'
     }
 
     sourceSets {
@@ -68,5 +69,11 @@ android {
 
     buildFeatures {
         prefab true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
     }
 }


### PR DESCRIPTION
## Problem

`packages/gamepads_android/android/build.gradle` unconditionally applied the Kotlin Gradle Plugin (`apply plugin: 'kotlin-android'`). Starting with Android Gradle Plugin (AGP) 9.0, support for applying KGP this way has been removed, which causes a compilation error that prevents consumers' apps from building.

Fixes #114

## Change

Follows Flutter's [migration guide for plugin authors](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors), using the backward-compatible variant:

- Apply `kotlin-android` only when AGP < 9. On AGP 9+, Flutter's built-in Kotlin support provides the `kotlin` extension.
- Removed the deprecated `kotlinOptions { jvmTarget = '1.8' }` block from inside `android {}`.
- Added the top-level `kotlin { compilerOptions { jvmTarget = ... } }` DSL.

The conditional approach is used instead of the full migration because the latter requires bumping the minimum to Flutter 3.44/Dart 3.12. This package currently targets `flutter: ">=3.35.0"`, so a hard bump would be a breaking change for users on older Flutter. This variant supports both AGP < 9 and AGP 9+ without raising the minimum.

## Notes

- `CHANGELOG.md` left untouched since it is generated from conventional commits via the release tooling.
- Not compile-verified locally (no Android toolchain available in the dev environment).