### PR TITLE
chore: Migrate to Melos 8

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           flutter-version: ${{env.FLUTTER_MIN_VERSION}}
       - uses: bluefireteam/melos-action@v3
-      - run: melos exec dart analyze .
+      - run: melos analyze
 
   analyze-latest:
     runs-on: ubuntu-latest

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,8 +51,8 @@ For a contribution to be accepted:
 
 - Follow the [Style Guide] when writing the code;
 - Format the code using `dart format .`;
-- Lint the code with `melos run analyze`;
-- Check that all tests pass: `melos run test`;
+- Lint the code with `melos analyze`;
+- Check that all tests pass: `melos test`;
 - Documentation should always be updated or added (if applicable);
 - Examples should always be updated or added (if applicable);
 - Tests should always be updated or added (if applicable) -- check the [Test writing guide] for

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
 
 dev_dependencies:
-  melos: ^7.5.1
+  melos: ^8.2.0
 
 melos:
   command:
@@ -33,12 +33,8 @@ melos:
 
   scripts:
     lint:
-      run: melos run analyze && melos run format
+      run: melos analyze -c 10 && melos run format
       description: Run all static analysis checks.
-
-    analyze:
-      run: melos exec -c 10 flutter analyze --fatal-infos
-      description: Run `flutter analyze` for all packages.
 
     format:
       run: melos exec dart format . --fix
@@ -53,14 +49,4 @@ melos:
       description: Run dartdoc checks for all non-example packages.
       packageFilters:
         ignore: "*_example"
-
-    test:select:
-      run: melos exec flutter test
-      packageFilters:
-        dirExists: test
-      description: Run `flutter test` for selected packages.
-
-    test:
-      run: melos run test:select --no-select
-      description: Run all Flutter tests in this project.
 


### PR DESCRIPTION
## Description

Migrates the repository from Melos 7.x to Melos 8.2.0 and adopts the new built-in `analyze` and `test` commands.

### Changes

- Bump `melos` to `^8.2.0`.
- Remove the custom `analyze`, `test` and `test:select` scripts in favor of the built-in `melos analyze` and `melos test` commands.
  - `melos test` auto-selects packages with a `test/` directory and picks `flutter test`/`dart test` per package.
  - `melos analyze` auto-picks `flutter analyze`/`dart analyze` per package, and as of 8.2.0 defaults to `--fatal-infos`, so no explicit flag is needed.
- Keep the `format` / `format-check` / `dartdoc` scripts (the built-in `melos format` has no `--fix`).
- Update the CI analyze job and `CONTRIBUTING.md` to use the built-in commands.

### Notes on the 7.x -> 8.0.0 migration

The only breaking change in the [migration guide](https://melos.invertase.dev/guides/migrations#7xx-to-800) is the `exec` script restructuring (`run` + `exec:` block -> `exec.command`). This repo only uses the `run: melos exec ...` shorthand, so no conversion was required.

### Verification (Melos 8.2.0)

- `melos bootstrap` -> 11 packages bootstrapped
- `melos analyze` -> runs `dart analyze --fatal-infos` -> success
- `melos test` -> all tests passed
- `melos run format-check` -> success