### PR TITLE
fix(android): Correct gamepad device detection and stop breaking keyboard input

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,9 +213,12 @@ class MainActivity: FlutterActivity(), GamepadsCompatibleActivity {
     var motionListener: ((MotionEvent) -> Boolean)? = null
 
     override fun dispatchGenericMotionEvent(motionEvent: MotionEvent): Boolean {
-        return motionListener?.invoke(motionEvent) ?: false
+        if (motionListener?.invoke(motionEvent) == true) {
+            return true
+        }
+        return super.dispatchGenericMotionEvent(motionEvent)
     }
-    
+
     override fun dispatchKeyEvent(keyEvent: KeyEvent): Boolean {
         if (keyListener?.invoke(keyEvent) == true) {
             return true

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
@@ -35,6 +35,9 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private var genericMotionListener: View.OnGenericMotionListener? = null
 
   private fun listGamepads(): List<Map<String, String>>  {
+    if (!::devices.isInitialized) {
+      return emptyList()
+    }
     return devices.getDevices().map { device ->
       mapOf(
         "id" to device.key.toString(),
@@ -67,7 +70,16 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   }
 
   fun onAttachedToActivityShared(activity: Activity) {
-    val compatibleActivity = activity as GamepadsCompatibleActivity
+    val compatibleActivity = activity as? GamepadsCompatibleActivity
+    if (compatibleActivity == null) {
+      Log.e(
+        TAG,
+        "Gamepad support is disabled: ${activity.javaClass.name} does not " +
+          "implement GamepadsCompatibleActivity. See the 'Android Integration' " +
+          "section of the gamepads README for the required MainActivity setup."
+      )
+      return
+    }
     devices = DeviceListener { compatibleActivity.isGamepadsInputDevice(it) }
     events = EventListener()
     compatibleActivity.registerInputDeviceListener(devices, handler = null)

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsCompatibleActivity.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsCompatibleActivity.kt
@@ -8,10 +8,22 @@ import android.view.MotionEvent
 
 interface GamepadsCompatibleActivity {
     fun isGamepadsInputDevice(device: InputDevice): Boolean {
-        return device.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD
-                || device.sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
-                // Some bluetooth keyboards are identified as GamePad. Check if it is ALPHABETIC keyboard.
-                && device.keyboardType != InputDevice.KEYBOARD_TYPE_ALPHABETIC
+        val hasGamepadSource =
+            device.sources and InputDevice.SOURCE_GAMEPAD == InputDevice.SOURCE_GAMEPAD ||
+                device.sources and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
+        if (!hasGamepadSource) {
+            return false
+        }
+        // Some bluetooth keyboards claim a gamepad source, while some real
+        // controllers expose an alphabetic keyboard profile, so keyboard type
+        // alone cannot tell them apart. Real controllers report joystick axes
+        // (sticks, hats or triggers) and keyboards do not.
+        val hasJoystickAxes = device.motionRanges.any {
+            it.source and InputDevice.SOURCE_JOYSTICK == InputDevice.SOURCE_JOYSTICK
+        }
+        val isKeyboard =
+            device.keyboardType == InputDevice.KEYBOARD_TYPE_ALPHABETIC && !hasJoystickAxes
+        return !isKeyboard
     }
 
     fun registerInputDeviceListener(listener: InputManager.InputDeviceListener, handler: Handler?)


### PR DESCRIPTION
# Description

Fixes the Android device filter so bluetooth keyboards are no longer registered as gamepads (which caused all their key events to be consumed, breaking keyboard input app-wide), and so real controllers that expose a keyboard profile are no longer rejected.

## Root causes

- The alphabetic-keyboard exclusion added in #66 never worked for its target case: due to Kotlin operator precedence (`&&` binds tighter than `||`), the check parsed as `GAMEPAD || (JOYSTICK && notAlphabetic)`, so a keyboard claiming `SOURCE_GAMEPAD` still passed the filter. Since `EventListener.onKeyEvent` always returns `true`, every keystroke from such a keyboard was consumed and never reached Flutter.
- The flip side: controllers that report `KEYBOARD_TYPE_ALPHABETIC` (common for 8BitDo and some bluetooth controllers) but only claim `SOURCE_JOYSTICK` were rejected entirely, so they produced no gamepad events at all.

## Changes

- `GamepadsCompatibleActivity.isGamepadsInputDevice`: rewritten with explicit logic. A device must have a gamepad or joystick source, and keyboards are distinguished from controllers by whether the device reports any joystick-source motion ranges (sticks, hats, triggers) instead of by keyboard type alone. This fixes both directions of the misclassification.
- `GamepadsAndroidPlugin`: the hard `as GamepadsCompatibleActivity` cast is now a safe cast with a descriptive `Log.e` pointing to the README setup, so apps whose MainActivity is missing the boilerplate no longer crash at startup with an opaque `ClassCastException`. `listGamepads` returns an empty list instead of throwing in that state.
- README (package copies are symlinks): the example `dispatchGenericMotionEvent` now falls back to `super.dispatchGenericMotionEvent` instead of returning `false`, which previously swallowed all generic motion events (mouse hover, scroll wheel, trackpad) for the whole app.

Note: the unconditional consumption of key events from registered gamepads (dpad/back navigation, #61) is intentionally left out of scope.

Fixes #70

## Testing instructions

Verified that both the plugin and the README boilerplate compile by building a scratch Flutter app against the local `gamepads_android`, once with a plain `FlutterActivity` (graceful-degradation path) and once with the README MainActivity.

To verify on hardware:

1. Run an app using `gamepads` with the README MainActivity setup on an Android device.
2. Connect a bluetooth keyboard: typing should reach the app (previously dead if the keyboard claimed a gamepad source), and it should not appear in `Gamepads.list()`.
3. Connect a controller (ideally an 8BitDo or another controller that exposes a keyboard profile): it should appear in `Gamepads.list()` and emit button and axis events.
4. With a mouse connected, scroll and hover should still work in the app.
5. Remove the `GamepadsCompatibleActivity` implementation from MainActivity: the app should start normally and log an error explaining the missing setup instead of crashing.