### PR TITLE
fix: Correct inverted Android D-pad Up/Down (AXIS_HAT_Y double-inversion)

### DIFF
--- a/packages/gamepads/lib/src/mappings/android_mapping.dart
+++ b/packages/gamepads/lib/src/mappings/android_mapping.dart
@@ -78,12 +78,15 @@ class AndroidMapping extends PlatformMapping {
       ];
     }
     if (key == _dpadYAxis) {
+      // gamepads_android's EventListener already inverts AXIS_HAT_Y, so the
+      // value reaching here follows up = +1.0, down = -1.0 (the opposite of
+      // Android's native AXIS_HAT_Y convention). See issue #123.
       return [
         NormalizedButton(
           GamepadButton.dpadDown,
-          value > 0 ? 1.0 : 0.0,
+          value < 0 ? 1.0 : 0.0,
         ),
-        NormalizedButton(GamepadButton.dpadUp, value < 0 ? 1.0 : 0.0),
+        NormalizedButton(GamepadButton.dpadUp, value > 0 ? 1.0 : 0.0),
       ];
     }
     return const [];

--- a/packages/gamepads/test/mappings_test.dart
+++ b/packages/gamepads/test/mappings_test.dart
@@ -245,8 +245,16 @@ void main() {
       expect(right[1].button, GamepadButton.dpadRight);
       expect(right[1].value, 1.0);
 
-      // Android hat Y: positive = down
-      final down = mapping.normalizeDpadAxis('AXIS_HAT_Y', 1.0);
+      // gamepads_android's EventListener inverts AXIS_HAT_Y before it reaches
+      // the mapping, so +1.0 = up and -1.0 = down here (regression for #123:
+      // pressing up must emit dpadUp, not dpadDown).
+      final up = mapping.normalizeDpadAxis('AXIS_HAT_Y', 1.0);
+      expect(up[0].button, GamepadButton.dpadDown);
+      expect(up[0].value, 0.0);
+      expect(up[1].button, GamepadButton.dpadUp);
+      expect(up[1].value, 1.0);
+
+      final down = mapping.normalizeDpadAxis('AXIS_HAT_Y', -1.0);
       expect(down[0].button, GamepadButton.dpadDown);
       expect(down[0].value, 1.0);
       expect(down[1].button, GamepadButton.dpadUp);


### PR DESCRIPTION
## Summary

Fixes #123.

On Android, pressing the D-pad **Up** emitted `GamepadButton.dpadDown` (value 1.0), and Down emitted `dpadUp`. Root cause is a double inversion of the D-pad Y hat axis:

- `gamepads_android`'s `EventListener` registers `AXIS_HAT_Y` with `invert = true` (`EventListener.kt:27`), so the value delivered to Dart is already flipped to **up = +1.0 / down = −1.0** — the opposite of Android's native `AXIS_HAT_Y` (up = −1.0 / down = +1.0).
- `AndroidMapping.normalizeDpadAxis` still mapped per Android's native convention (`value > 0 → dpadDown`, `value < 0 → dpadUp`), so the two flips compounded.

`AXIS_HAT_X` is not inverted natively, so D-pad left/right were unaffected — matching the report.

## Change

Corrected the sign comparison in a single canonical location — the `AXIS_HAT_Y` branch of `AndroidMapping.normalizeDpadAxis` — so `dpadUp` fires on `value > 0` and `dpadDown` on `value < 0`, with a comment citing #123. `EventListener.kt` is intentionally left unchanged to avoid re-introducing a double-inversion.

- `packages/gamepads/lib/src/mappings/android_mapping.dart`
- `packages/gamepads/test/mappings_test.dart` — both-direction `AXIS_HAT_Y` regression

## Fix-location decision (maintainer call welcome)

The reporter raised a genuine design choice for *where* to fix this:
1. **Kotlin** (`EventListener.kt`): drop the `AXIS_HAT_Y` inversion → raw/unnormalized values would then follow Android's `1.0 == down`.
2. **Dart** (`android_mapping.dart`, this PR): keeps the library's existing `1.0 == up` raw convention.

This PR takes option 2 to preserve the current raw-value convention (no breaking change) and because the mapping is pure Dart and directly unit-testable. Happy to switch to the Kotlin approach if you prefer — but the fix must live in exactly one place; applying it in both would double-invert and silently reintroduce the bug.

## Tests

Added a both-direction regression to `AndroidMapping > "normalizes hat d-pad axes"`:
- raw `AXIS_HAT_Y = +1.0` (physical up) → `dpadUp = 1.0`, `dpadDown = 0.0`
- raw `AXIS_HAT_Y = -1.0` (physical down) → `dpadDown = 1.0`, `dpadUp = 0.0`

This fails on the pre-fix code (which returned `dpadDown = 1.0` for `+1.0`) and passes after the fix.

> **Note:** the containerized Flutter runner was gated in this non-interactive session, so the fail→pass transition was verified by tracing, not executed. Please run before merge:
> ```
> flutter pub get && flutter test packages/gamepads/test/mappings_test.dart
> flutter analyze packages/gamepads
> ```
> End-to-end hardware confirmation (physical Android device + controller, e.g. the reporter's SM-G781B + GameSir G8 Pro) is out of CI scope.

## Deferred

- **Analog stick Y-axis** (`leftStickY`/`rightStickY`): the reporter separately observed up reading `-1.0`. Left untouched here — confirm it's a genuine inversion vs. Android's native joystick convention before changing; tracked as a follow-up reusing this PR's convention decision.
- **CHANGELOG / version bump**: not hand-edited — this melos workspace generates them at release time from the `fix:` PR title (`CONTRIBUTING.md`, "Creating a release").

## Coordination

Thanks @fescrb for the precise root-cause analysis. You'd offered to submit this — glad to defer to you or just help with review; sharing this as a ready-to-go option while the fix-location question is settled.
