### PR TITLE
fix: Correct inverted Android stick Y axis and map the RX/RY right stick

### DIFF
--- a/packages/gamepads/lib/src/mappings/android_mapping.dart
+++ b/packages/gamepads/lib/src/mappings/android_mapping.dart
@@ -37,6 +37,10 @@ class AndroidMapping extends PlatformMapping {
     'AXIS_RTRIGGER': GamepadAxis.rightTrigger,
     'AXIS_BRAKE': GamepadAxis.leftTrigger,
     'AXIS_GAS': GamepadAxis.rightTrigger,
+    // Right-stick axes for non-Xbox layouts, which report the right stick on
+    // RX/RY instead of Z/RZ. E.g. the DJI RC Pro.
+    'AXIS_RX': GamepadAxis.rightStickX,
+    'AXIS_RY': GamepadAxis.rightStickY,
   };
 
   // D-pad hat axes on Android.
@@ -59,10 +63,9 @@ class AndroidMapping extends PlatformMapping {
       return const [];
     }
     // Android reports sticks in -1.0 to 1.0 and triggers in 0.0 to 1.0.
-    // Y-axis is inverted on Android (up = negative).
-    if (axis == GamepadAxis.leftStickY || axis == GamepadAxis.rightStickY) {
-      return [NormalizedAxis(axis, -value)];
-    }
+    // gamepads_android's EventListener already inverts the stick Y axes
+    // (AXIS_Y, AXIS_RZ and AXIS_RY), so the values reaching here follow
+    // up = +1.0, down = -1.0 and must not be negated again. See issue #123.
     return [NormalizedAxis(axis, value)];
   }
 
@@ -78,9 +81,8 @@ class AndroidMapping extends PlatformMapping {
       ];
     }
     if (key == _dpadYAxis) {
-      // gamepads_android's EventListener already inverts AXIS_HAT_Y, so the
-      // value reaching here follows up = +1.0, down = -1.0 (the opposite of
-      // Android's native AXIS_HAT_Y convention). See issue #123.
+      // As with the stick Y axes above, EventListener already inverts
+      // AXIS_HAT_Y, so up = +1.0 and down = -1.0 here.
       return [
         NormalizedButton(
           GamepadButton.dpadDown,

--- a/packages/gamepads/lib/src/mappings/platform_mapping.dart
+++ b/packages/gamepads/lib/src/mappings/platform_mapping.dart
@@ -25,10 +25,12 @@ class NormalizedAxis {
 ///
 /// **Y-axis convention**: Normalized stick Y values use up = +1.0,
 /// down = -1.0. Platforms where the native API reports the opposite
-/// (e.g., iOS, Android, Web) must negate Y in their [normalizeAxis].
+/// (e.g., iOS, Web) must negate Y in their [normalizeAxis].
 /// macOS GCController already reports up = positive natively, so no
-/// inversion is needed there. Linux/Windows handle inversion via the
-/// `yAxisInverted` flag in `ControllerMapping`.
+/// inversion is needed there. Android is inverted by the
+/// `gamepads_android` plugin before the event reaches Dart, so its
+/// mapping must not negate Y again. Linux/Windows handle inversion via
+/// the `yAxisInverted` flag in `ControllerMapping`.
 abstract class PlatformMapping {
   /// Attempts to normalize a button event.
   ///

--- a/packages/gamepads/test/gamepad_normalizer_test.dart
+++ b/packages/gamepads/test/gamepad_normalizer_test.dart
@@ -94,7 +94,7 @@ void main() {
         expect(results.first.button, GamepadButton.a);
       });
 
-      test('normalizes Android axis with Y inversion', () {
+      test('keeps the Android Y axis inverted by the plugin', () {
         final event = GamepadEvent(
           gamepadId: 'pad1',
           timestamp: 1000,
@@ -105,7 +105,7 @@ void main() {
 
         final results = normalizer.normalize(event);
         expect(results.first.axis, GamepadAxis.leftStickY);
-        expect(results.first.value, -1.0);
+        expect(results.first.value, 1.0);
       });
     });
 

--- a/packages/gamepads/test/mappings_test.dart
+++ b/packages/gamepads/test/mappings_test.dart
@@ -202,17 +202,28 @@ void main() {
       );
     });
 
-    test('normalizes stick axes with Y inversion', () {
+    test('normalizes stick axes without inverting Y again', () {
       final lx = mapping.normalizeAxis('AXIS_X', 0.5);
       expect(lx.first.axis, GamepadAxis.leftStickX);
       expect(lx.first.value, 0.5);
 
-      // Y-axis should be inverted
+      // EventListener already inverted AXIS_Y and AXIS_RZ, so a positive
+      // value here means up and must be passed through unchanged.
       final ly = mapping.normalizeAxis('AXIS_Y', 0.5);
       expect(ly.first.axis, GamepadAxis.leftStickY);
-      expect(ly.first.value, -0.5);
+      expect(ly.first.value, 0.5);
 
       final ry = mapping.normalizeAxis('AXIS_RZ', -1.0);
+      expect(ry.first.axis, GamepadAxis.rightStickY);
+      expect(ry.first.value, -1.0);
+    });
+
+    test('normalizes the alternate right stick axes', () {
+      final rx = mapping.normalizeAxis('AXIS_RX', 0.5);
+      expect(rx.first.axis, GamepadAxis.rightStickX);
+      expect(rx.first.value, 0.5);
+
+      final ry = mapping.normalizeAxis('AXIS_RY', 1.0);
       expect(ry.first.axis, GamepadAxis.rightStickY);
       expect(ry.first.value, 1.0);
     });
@@ -245,9 +256,9 @@ void main() {
       expect(right[1].button, GamepadButton.dpadRight);
       expect(right[1].value, 1.0);
 
-      // gamepads_android's EventListener inverts AXIS_HAT_Y before it reaches
-      // the mapping, so +1.0 = up and -1.0 = down here (regression for #123:
-      // pressing up must emit dpadUp, not dpadDown).
+      // EventListener inverts AXIS_HAT_Y before it reaches the mapping, so
+      // +1.0 = up and -1.0 = down here (regression for #123: pressing up
+      // must emit dpadUp, not dpadDown).
       final up = mapping.normalizeDpadAxis('AXIS_HAT_Y', 1.0);
       expect(up[0].button, GamepadButton.dpadDown);
       expect(up[0].value, 0.0);

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/EventListener.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/EventListener.kt
@@ -18,6 +18,12 @@ class EventListener {
     }
     private val lastAxisValue = mutableMapOf<Int, Float>()
     // Reference: https://developer.android.com/reference/android/view/MotionEvent
+    //
+    // The vertical axes are inverted here so that the values sent to Dart
+    // follow up = +1.0, down = -1.0 instead of Android's native convention.
+    // AndroidMapping in the gamepads package relies on that and does not
+    // invert them again, so removing an `invert` below silently flips the
+    // corresponding stick or d-pad direction. See issue #123.
     private val supportedAxes = listOf(
         SupportedAxis(MotionEvent.AXIS_X),
         SupportedAxis(MotionEvent.AXIS_Y, invert = true),


### PR DESCRIPTION
Follow-up to #128, which fixed the same double inversion for the d-pad hat axis but left the analog sticks inconsistent with it. Also closes the second symptom reported in #123.

## Stick Y axis was double inverted

`gamepads_android`'s `EventListener` registers `AXIS_Y`, `AXIS_RZ` and `AXIS_RY` with `invert = true`, so a physical stick-up already arrives in Dart as `+1.0`. `AndroidMapping.normalizeAxis` negated it a second time:

```dart
if (axis == GamepadAxis.leftStickY || axis == GamepadAxis.rightStickY) {
  return [NormalizedAxis(axis, -value)];
}
```

The result was `leftStickY = -1.0` for up on Android, while the same gesture gives `+1.0` on iOS, macOS and Web. That contradicts the convention documented on `GamepadAxis` and `PlatformMapping` ("Left/Down = -1, Right/Up = +1"), so cross-platform game code moved the player in opposite directions.

After #128 the file also argued both ways: "EventListener already inverted it" for the hat axis, and the opposite three lines above for the sticks.

## RX/RY right stick events were dropped

`EventListener` reports `AXIS_RX` and `AXIS_RY` (added in #111 for non-Xbox layouts such as the DJI RC Pro), but they were missing from `_axisMap`. Unmatched analog keys fall through to `normalizeDpadAxis`, which returns `const []` for anything that is not a hat axis, so those events were discarded. On a DJI RC Pro the right stick produced no normalized events at all.

Both are mapped to `rightStickX`/`rightStickY`, the same aliasing pattern already used for `AXIS_BRAKE`/`AXIS_GAS`.

## Guarding the cross-package invariant

`AndroidMapping`'s correctness depends on the `invert = true` flags staying in the separately versioned Kotlin plugin, and until now the only trace of that was a comment on the Dart side. `EventListener.kt` is the more obvious place for a contributor to "fix" against Android's documentation, and doing so would silently re-invert everything without a single test failing, since the tests only exercise the Dart half. Added a counterpart comment next to `supportedAxes` pointing back at the Dart mapping.

`AXIS_WHEEL` is still reported by `EventListener` and still unmapped, since there is no matching `GamepadAxis`. It stays available through the raw event API.

## Changes

- `packages/gamepads/lib/src/mappings/android_mapping.dart`
- `packages/gamepads/lib/src/mappings/platform_mapping.dart`, the Y-axis contract no longer lists Android as a platform that must negate
- `packages/gamepads_android/.../EventListener.kt`, comment only
- `packages/gamepads/test/mappings_test.dart`, stick assertions corrected, new RX/RY test
- `packages/gamepads/test/gamepad_normalizer_test.dart`, the `AXIS_Y` test asserted the buggy `-1.0`

## Verification

`melos analyze` is clean, `dart format` reports no changes, and all 80 tests in `packages/gamepads` pass. Hardware confirmation on a physical Android device is still worth doing before release.

https://claude.ai/code/session_019aEP4Np5vqDw5BkgGYyHe7