### PR TITLE
chore(release): Drop build numbers from versions and update melos to 8.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,59 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+## 2026-08-25
+
+### Changes
+
+---
+
+Packages with breaking changes:
+
+ - There are no breaking changes in this release.
+
+Packages with other changes:
+
+ - [`gamepads_android` - `v0.1.9`](#gamepads_android---v019)
+ - [`gamepads_darwin` - `v0.1.3`](#gamepads_darwin---v013)
+ - [`gamepads_ios` - `v0.1.4`](#gamepads_ios---v014)
+ - [`gamepads_web` - `v0.1.2`](#gamepads_web---v012)
+ - [`gamepads_windows` - `v0.3.1`](#gamepads_windows---v031)
+ - [`gamepads` - `v0.1.11`](#gamepads---v0111)
+ - [`flutter_gamepads` - `v0.1.12`](#flutter_gamepads---v0112)
+
+---
+
+#### `gamepads_android` - `v0.1.9`
+
+ - **FIX**: Correct inverted Android stick Y axis and map the RX/RY right stick ([#129](https://github.com/flame-engine/gamepads/issues/129)). ([18c18861](https://github.com/flame-engine/gamepads/commit/18c188614ffbeb9241b24c00ab50e8c6ef48d802))
+ - **FIX**(android): Correct gamepad device detection and stop breaking keyboard input ([#127](https://github.com/flame-engine/gamepads/issues/127)). ([50843a0c](https://github.com/flame-engine/gamepads/commit/50843a0ccfb395af7cba5083fff47789c3fa8cae))
+
+#### `gamepads_darwin` - `v0.1.3`
+
+ - **FEAT**: Add Swift Package Manager support ([#126](https://github.com/flame-engine/gamepads/issues/126)). ([4552f041](https://github.com/flame-engine/gamepads/commit/4552f041ebe90127356a4b62be3bfb6c3b9eeb22))
+
+#### `gamepads_ios` - `v0.1.4`
+
+ - **FEAT**: Add Swift Package Manager support ([#126](https://github.com/flame-engine/gamepads/issues/126)). ([4552f041](https://github.com/flame-engine/gamepads/commit/4552f041ebe90127356a4b62be3bfb6c3b9eeb22))
+
+#### `gamepads_web` - `v0.1.2`
+
+ - Bump "gamepads_web" to `0.1.2`.
+
+#### `gamepads_windows` - `v0.3.1`
+
+ - Bump "gamepads_windows" to `0.3.1`.
+
+#### `gamepads` - `v0.1.11`
+
+ - **FIX**: Correct inverted Android stick Y axis and map the RX/RY right stick ([#129](https://github.com/flame-engine/gamepads/issues/129)). ([18c18861](https://github.com/flame-engine/gamepads/commit/18c188614ffbeb9241b24c00ab50e8c6ef48d802))
+ - **FIX**: Correct inverted Android D-pad Up/Down (AXIS_HAT_Y double-inversion) ([#128](https://github.com/flame-engine/gamepads/issues/128)). ([88711197](https://github.com/flame-engine/gamepads/commit/88711197daa978cab220f85ce2a6cc9850e1c24d))
+
+#### `flutter_gamepads` - `v0.1.12`
+
+ - **FIX**: Remove use of flutter/material.dart in flutter_gamepads ([#125](https://github.com/flame-engine/gamepads/issues/125)). ([9b1434ae](https://github.com/flame-engine/gamepads/commit/9b1434aef1a79f4228868484f57d43b4deb068c3))
+
+
 ## 2026-07-07
 
 ### Changes
@@ -473,9 +526,9 @@ Packages with other changes:
  - [`gamepads_platform_interface` - `v0.1.2+1`](#gamepads_platform_interface---v0121)
  - [`gamepads_linux` - `v0.1.1+3`](#gamepads_linux---v0113)
  - [`gamepads_windows` - `v0.1.1+3`](#gamepads_windows---v0113)
- - [`gamepads_darwin` - `v0.1.2+2`](#gamepads_darwin---v0122)
- - [`gamepads_ios` - `v0.1.2+2`](#gamepads_ios---v0122)
- - [`gamepads_android` - `v0.1.2+2`](#gamepads_android---v0122)
+ - [`gamepads_darwin` - `v0.1.2`](#gamepads_darwin---v0122)
+ - [`gamepads_ios` - `v0.1.2`](#gamepads_ios---v0122)
+ - [`gamepads_android` - `v0.1.2`](#gamepads_android---v0122)
 
 Packages with dependency updates only:
 
@@ -483,9 +536,9 @@ Packages with dependency updates only:
 
  - `gamepads_linux` - `v0.1.1+3`
  - `gamepads_windows` - `v0.1.1+3`
- - `gamepads_darwin` - `v0.1.2+2`
- - `gamepads_ios` - `v0.1.2+2`
- - `gamepads_android` - `v0.1.2+2`
+ - `gamepads_darwin` - `v0.1.2`
+ - `gamepads_ios` - `v0.1.2`
+ - `gamepads_android` - `v0.1.2`
 
 ---
 

--- a/packages/flutter_gamepads/CHANGELOG.md
+++ b/packages/flutter_gamepads/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.12
+
+ - **FIX**: Remove use of flutter/material.dart in flutter_gamepads ([#125](https://github.com/flame-engine/gamepads/issues/125)). ([9b1434ae](https://github.com/flame-engine/gamepads/commit/9b1434aef1a79f4228868484f57d43b4deb068c3))
+
 ## 0.1.11+4
 
  - Update a dependency to the latest release.

--- a/packages/flutter_gamepads/example/pubspec.yaml
+++ b/packages/flutter_gamepads/example/pubspec.yaml
@@ -13,8 +13,8 @@ dependencies:
   flame: ^1.32.0
   flutter:
     sdk: flutter
-  flutter_gamepads: ^0.1.11+4
-  gamepads: ^0.1.10+5
+  flutter_gamepads: ^0.1.12
+  gamepads: ^0.1.11
 
 dev_dependencies:
   flame_lint: ^1.4.1

--- a/packages/flutter_gamepads/pubspec.yaml
+++ b/packages/flutter_gamepads/pubspec.yaml
@@ -1,7 +1,7 @@
 name: flutter_gamepads
 resolution: workspace
 description: A Flutter package that maps gamepad input to UI interaction.
-version: 0.1.11+4
+version: 0.1.12
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/flutter_gamepads
 
@@ -14,7 +14,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  gamepads: ^0.1.10+5
+  gamepads: ^0.1.11
 
 dev_dependencies:
   flame_lint: ^1.4.1

--- a/packages/gamepads/CHANGELOG.md
+++ b/packages/gamepads/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.11
+
+ - **FIX**: Correct inverted Android stick Y axis and map the RX/RY right stick ([#129](https://github.com/flame-engine/gamepads/issues/129)). ([18c18861](https://github.com/flame-engine/gamepads/commit/18c188614ffbeb9241b24c00ab50e8c6ef48d802))
+ - **FIX**: Correct inverted Android D-pad Up/Down (AXIS_HAT_Y double-inversion) ([#128](https://github.com/flame-engine/gamepads/issues/128)). ([88711197](https://github.com/flame-engine/gamepads/commit/88711197daa978cab220f85ce2a6cc9850e1c24d))
+
 ## 0.1.10+5
 
  - Update a dependency to the latest release.

--- a/packages/gamepads/example/pubspec.yaml
+++ b/packages/gamepads/example/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  gamepads: ^0.1.10+5
+  gamepads: ^0.1.11
   share_plus: ^10.0.0
   web: ^1.1.1
 

--- a/packages/gamepads/pubspec.yaml
+++ b/packages/gamepads/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gamepads
 resolution: workspace
 description: A Flutter plugin to handle gamepad input across multiple platforms.
-version: 0.1.10+5
+version: 0.1.11
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/gamepads
 
@@ -28,13 +28,13 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  gamepads_android: ^0.1.8+2
-  gamepads_darwin: ^0.1.2+4
-  gamepads_ios: ^0.1.3+3
+  gamepads_android: ^0.1.9
+  gamepads_darwin: ^0.1.3
+  gamepads_ios: ^0.1.4
   gamepads_linux: ^0.1.2
   gamepads_platform_interface: ^0.1.3
-  gamepads_web: ^0.1.1+1
-  gamepads_windows: ^0.3.0+1
+  gamepads_web: ^0.1.2
+  gamepads_windows: ^0.3.1
 
 dev_dependencies:
   flame_lint: ^1.4.1

--- a/packages/gamepads_android/CHANGELOG.md
+++ b/packages/gamepads_android/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.9
+
+ - **FIX**: Correct inverted Android stick Y axis and map the RX/RY right stick ([#129](https://github.com/flame-engine/gamepads/issues/129)). ([18c18861](https://github.com/flame-engine/gamepads/commit/18c188614ffbeb9241b24c00ab50e8c6ef48d802))
+ - **FIX**(android): Correct gamepad device detection and stop breaking keyboard input ([#127](https://github.com/flame-engine/gamepads/issues/127)). ([50843a0c](https://github.com/flame-engine/gamepads/commit/50843a0ccfb395af7cba5083fff47789c3fa8cae))
+
 ## 0.1.8+2
 
  - **FIX**(android): Avoid KGP warning on AGP 8.x with built-in Kotlin ([#120](https://github.com/flame-engine/gamepads/issues/120)). ([291d43e8](https://github.com/flame-engine/gamepads/commit/291d43e83f33f05d1c1c29623d66b7097b4a7b5d))
@@ -33,7 +38,7 @@
 
  - **FEAT**: Add AXIS_BRAKE and AXIS_GAS as supported axes on Android. ([#50](https://github.com/flame-engine/gamepads/issues/50)). ([adfb8d1f](https://github.com/flame-engine/gamepads/commit/adfb8d1fa2206571d6c59315697d3cf9c951b423))
 
-## 0.1.2+2
+## 0.1.2
 
  - Update a dependency to the latest release.
 

--- a/packages/gamepads_android/pubspec.yaml
+++ b/packages/gamepads_android/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gamepads_android
 resolution: workspace
 description: Android implementation of gamepads, a Flutter plugin to handle gamepad input across multiple platforms.
-version: 0.1.8+2
+version: 0.1.9
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/gamepads_android
 

--- a/packages/gamepads_darwin/CHANGELOG.md
+++ b/packages/gamepads_darwin/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+ - **FEAT**: Add Swift Package Manager support ([#126](https://github.com/flame-engine/gamepads/issues/126)). ([4552f041](https://github.com/flame-engine/gamepads/commit/4552f041ebe90127356a4b62be3bfb6c3b9eeb22))
+
 ## 0.1.2+4
 
  - **FIX**: Use typed GCController properties for macOS system button mapping ([#96](https://github.com/flame-engine/gamepads/issues/96)). ([b4264e48](https://github.com/flame-engine/gamepads/commit/b4264e481abc5755725d3b1c7626b759f71bb1d4))
@@ -6,7 +10,7 @@
 
  - Update a dependency to the latest release.
 
-## 0.1.2+2
+## 0.1.2
 
  - Update a dependency to the latest release.
 

--- a/packages/gamepads_darwin/pubspec.yaml
+++ b/packages/gamepads_darwin/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gamepads_darwin
 resolution: workspace
 description: MacOS implementation of gamepads, a Flutter plugin to handle gamepad input across multiple platforms.
-version: 0.1.2+4
+version: 0.1.3
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/gamepads_darwin
 

--- a/packages/gamepads_ios/CHANGELOG.md
+++ b/packages/gamepads_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4
+
+ - **FEAT**: Add Swift Package Manager support ([#126](https://github.com/flame-engine/gamepads/issues/126)). ([4552f041](https://github.com/flame-engine/gamepads/commit/4552f041ebe90127356a4b62be3bfb6c3b9eeb22))
+
 ## 0.1.3+3
 
  - **FIX**: Correct trigger handling for iOS. ([#94](https://github.com/flame-engine/gamepads/issues/94)). ([17c2f907](https://github.com/flame-engine/gamepads/commit/17c2f9079a83d991a13ad2f45f40374135fc09d9))
@@ -15,7 +19,7 @@
 
  - **FIX**: Correct dpad axis mapping and add support for start/select/home buttons (iOS) ([#65](https://github.com/flame-engine/gamepads/issues/65)). ([1aef0c28](https://github.com/flame-engine/gamepads/commit/1aef0c2881db84b78f68f23b754912a2625b7902))
 
-## 0.1.2+2
+## 0.1.2
 
  - Update a dependency to the latest release.
 

--- a/packages/gamepads_ios/pubspec.yaml
+++ b/packages/gamepads_ios/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gamepads_ios
 resolution: workspace
 description: iOS implementation of gamepads, a Flutter plugin to handle gamepad input across multiple platforms.
-version: 0.1.3+3
+version: 0.1.4
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/gamepads_ios
 

--- a/packages/gamepads_web/CHANGELOG.md
+++ b/packages/gamepads_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+ - Bump "gamepads_web" to `0.1.2`.
+
 ## 0.1.1+1
 
  - **FIX**: Remove unused dependency that causes package:js dependency ([#103](https://github.com/flame-engine/gamepads/issues/103)). ([0463612b](https://github.com/flame-engine/gamepads/commit/0463612b646e187d3dc1cac3424167a042b9cf1b))

--- a/packages/gamepads_web/pubspec.yaml
+++ b/packages/gamepads_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gamepads_web
 resolution: workspace
 description: Web implementation of gamepads, a Flutter plugin to handle gamepad input across multiple platforms.
-version: 0.1.1+1
+version: 0.1.2
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/gamepads_web
 

--- a/packages/gamepads_windows/CHANGELOG.md
+++ b/packages/gamepads_windows/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1
+
+ - Bump "gamepads_windows" to `0.3.1`.
+
 ## 0.3.0+1
 
  - **FIX**: Improved performance on windows ([#54](https://github.com/flame-engine/gamepads/issues/54)) ([#100](https://github.com/flame-engine/gamepads/issues/100)). ([f4efa60b](https://github.com/flame-engine/gamepads/commit/f4efa60bc443e1aed930f224e081c3e9ddc39699))

--- a/packages/gamepads_windows/pubspec.yaml
+++ b/packages/gamepads_windows/pubspec.yaml
@@ -1,7 +1,7 @@
 name: gamepads_windows
 resolution: workspace
 description: Windows implementation of gamepads, a Flutter plugin to handle gamepad input across multiple platforms.
-version: 0.3.0+1
+version: 0.3.1
 homepage: https://github.com/flame-engine/gamepads
 repository: https://github.com/flame-engine/gamepads/tree/main/packages/gamepads_windows
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,7 @@ environment:
   sdk: '>=3.9.0 <4.0.0'
 
 dev_dependencies:
-  melos: ^8.2.0
+  melos: ^8.4.0
 
 melos:
   command:


### PR DESCRIPTION
## Description

Removes the `+x` build numbers from all package versions and updates melos to `^8.4.0`.

Every `+x` version was the currently published one on pub.dev, so plain stripping would have produced versions that sort lower than what is published. Each package got a patch bump instead, with the build number dropped:

| Package | Before | After |
|---|---|---|
| gamepads_android | 0.1.8+2 | 0.1.9 |
| gamepads_darwin | 0.1.2+4 | 0.1.3 |
| gamepads_ios | 0.1.3+3 | 0.1.4 |
| gamepads_web | 0.1.1+1 | 0.1.2 |
| gamepads_windows | 0.3.0+1 | 0.3.1 |
| gamepads | 0.1.10+5 | 0.1.11 |
| flutter_gamepads | 0.1.11+4 | 0.1.12 |

Internal dependency constraints and changelogs were generated with `melos version` from the unreleased commits (#125 to #129). `gamepads_web` and `gamepads_windows` had no unreleased changes and are only bumped to drop the suffix.

Melos 8.x bumps the patch version for fixes and dependency updates on 0.x packages and only keeps a build number when the current version already has one, so with these clean versions no `+x` will be reintroduced by future `melos version` runs. 8.4.0 is the latest release and requires `sdk: ^3.9.0`, which matches the workspace minimum.

## Checklist

- [x] The title of my PR starts with a [Conventional Commit] prefix (`fix:`, `feat:`, `docs:` etc).
- [x] I have read the [Contributor Guide] and followed the process outlined for submitting PRs.
- [x] I have updated/added tests for ALL new/updated/fixed functionality.
- [x] I have updated/added relevant documentation in `docs` and added dartdoc comments with `///`.
- [x] I have updated/added relevant examples in `examples`.

## Breaking Change

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

https://claude.ai/code/session_01ECm9j87ohzVbQSagq7qe8M

[Conventional Commit]: https://conventionalcommits.org
[Contributor Guide]: https://github.com/flame-engine/gamepads/blob/main/CONTRIBUTING.md
