### PR TITLE
feat: Add connect and disconnect event streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ class GamepadConnectionEvent {
   final String name;
 
   /// Whether the gamepad was connected or disconnected.
-  final GamepadConnectionType type;
+  final GamepadConnectionEventType type;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,40 @@ It also reports `vendorId` and `productId` where the platform provides them, so 
 identify a connected gamepad (e.g. "Sony DualSense") before it sends any input. These are
 `null` on macOS and iOS, where `GCController` does not expose vendor/product ids.
 
+To react to gamepads being plugged in and unplugged instead of polling `list`,
+listen to `onConnected` and `onDisconnected`:
+
+```dart
+Gamepads.onConnected.listen((event) {
+  print('${event.name} (${event.gamepadId}) connected');
+});
+
+Gamepads.onDisconnected.listen((event) {
+  print('${event.name} (${event.gamepadId}) disconnected');
+});
+```
+
+Both are filtered views of `connectionEvents`, which emits a
+`GamepadConnectionEvent` for either case:
+
+```dart
+class GamepadConnectionEvent {
+  /// The id of the gamepad controller that was connected or disconnected.
+  final String gamepadId;
+
+  /// A user-facing, platform-dependant name for the gamepad controller.
+  final String name;
+
+  /// Whether the gamepad was connected or disconnected.
+  final GamepadConnectionType type;
+}
+```
+
+The `gamepadId` matches the `GamepadController.id` returned by `list` and the
+`GamepadEvent.gamepadId` of the events fired by that gamepad. Only gamepads
+that connect while your app is running are reported, so call `list` once at
+startup to pick up the ones that were already connected.
+
 Listen to `normalizedEvents` for gamepad input with consistent
 button/axis names and value ranges across all platforms:
 

--- a/packages/gamepads/example/lib/main.dart
+++ b/packages/gamepads/example/lib/main.dart
@@ -43,6 +43,7 @@ class _EventEntry {
 
 class _MyHomePageState extends State<MyHomePage> {
   StreamSubscription<GamepadEvent>? _subscription;
+  StreamSubscription<GamepadConnectionEvent>? _connectionSubscription;
   late final GamepadNormalizer _normalizer;
 
   List<GamepadController> _gamepads = [];
@@ -81,6 +82,13 @@ class _MyHomePageState extends State<MyHomePage> {
   void initState() {
     super.initState();
     _normalizer = GamepadNormalizer();
+    _connectionSubscription = Gamepads.connectionEvents.listen((event) {
+      _eventLog.add(
+        '${DateTime.now().toIso8601String()} '
+        '[${event.name}] ${event.type.name}',
+      );
+      _listGamepads();
+    });
     _subscription = Gamepads.events.listen((event) {
       if (!_gamepadNames.containsKey(event.gamepadId)) {
         _listGamepads();
@@ -131,6 +139,7 @@ class _MyHomePageState extends State<MyHomePage> {
   @override
   void dispose() {
     _subscription?.cancel();
+    _connectionSubscription?.cancel();
     super.dispose();
   }
 

--- a/packages/gamepads/lib/gamepads.dart
+++ b/packages/gamepads/lib/gamepads.dart
@@ -1,3 +1,4 @@
+export 'package:gamepads_platform_interface/api/gamepad_connection_event.dart';
 export 'package:gamepads_platform_interface/api/gamepad_controller.dart';
 export 'package:gamepads_platform_interface/api/gamepad_event.dart';
 

--- a/packages/gamepads/lib/src/gamepads.dart
+++ b/packages/gamepads/lib/src/gamepads.dart
@@ -2,6 +2,7 @@ library gamepads;
 
 import 'package:gamepads/src/api/normalized_gamepad_event.dart';
 import 'package:gamepads/src/gamepad_normalizer.dart';
+import 'package:gamepads_platform_interface/api/gamepad_connection_event.dart';
 import 'package:gamepads_platform_interface/api/gamepad_controller.dart';
 import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
@@ -55,4 +56,22 @@ class Gamepads {
   static Stream<GamepadEvent> eventsByGamepad(String gamepadId) {
     return events.where((event) => event.gamepadId == gamepadId);
   }
+
+  /// A stream of gamepads being connected to and disconnected from the device.
+  ///
+  /// Use [onConnected] or [onDisconnected] to listen to only one of the two.
+  static Stream<GamepadConnectionEvent> get connectionEvents =>
+      _platform.gamepadConnectionEventsStream;
+
+  /// A stream that emits whenever a gamepad is connected.
+  static Stream<GamepadConnectionEvent> get onConnected =>
+      connectionEvents.where(
+        (event) => event.type == GamepadConnectionType.connected,
+      );
+
+  /// A stream that emits whenever a gamepad is disconnected.
+  static Stream<GamepadConnectionEvent> get onDisconnected =>
+      connectionEvents.where(
+        (event) => event.type == GamepadConnectionType.disconnected,
+      );
 }

--- a/packages/gamepads/lib/src/gamepads.dart
+++ b/packages/gamepads/lib/src/gamepads.dart
@@ -66,12 +66,12 @@ class Gamepads {
   /// A stream that emits whenever a gamepad is connected.
   static Stream<GamepadConnectionEvent> get onConnected =>
       connectionEvents.where(
-        (event) => event.type == GamepadConnectionType.connected,
+        (event) => event.type == GamepadConnectionEventType.connected,
       );
 
   /// A stream that emits whenever a gamepad is disconnected.
   static Stream<GamepadConnectionEvent> get onDisconnected =>
       connectionEvents.where(
-        (event) => event.type == GamepadConnectionType.disconnected,
+        (event) => event.type == GamepadConnectionEventType.disconnected,
       );
 }

--- a/packages/gamepads/test/gamepads_test.dart
+++ b/packages/gamepads/test/gamepads_test.dart
@@ -131,7 +131,7 @@ void main() {
     final event = await listener;
     expect(event.gamepadId, '1');
     expect(event.name, 'Test Controller');
-    expect(event.type, GamepadConnectionType.connected);
+    expect(event.type, GamepadConnectionEventType.connected);
   });
 
   test('onConnected only emits connection events', () async {
@@ -158,7 +158,7 @@ void main() {
     );
     final event = await listener;
     expect(event.gamepadId, '2');
-    expect(event.type, GamepadConnectionType.connected);
+    expect(event.type, GamepadConnectionEventType.connected);
   });
 
   test('onDisconnected only emits disconnection events', () async {
@@ -185,6 +185,6 @@ void main() {
     );
     final event = await listener;
     expect(event.gamepadId, '2');
-    expect(event.type, GamepadConnectionType.disconnected);
+    expect(event.type, GamepadConnectionEventType.disconnected);
   });
 }

--- a/packages/gamepads/test/gamepads_test.dart
+++ b/packages/gamepads/test/gamepads_test.dart
@@ -115,4 +115,76 @@ void main() {
       expect(event.value, 1.0);
     },
   );
+
+  test('can listen to connection events through platform interface', () async {
+    final listener = Gamepads.connectionEvents.first;
+    await platformInterface.platformCallHandler(
+      const MethodCall(
+        'onGamepadConnectionEvent',
+        <String, dynamic>{
+          'gamepadId': '1',
+          'name': 'Test Controller',
+          'type': 'connected',
+        },
+      ),
+    );
+    final event = await listener;
+    expect(event.gamepadId, '1');
+    expect(event.name, 'Test Controller');
+    expect(event.type, GamepadConnectionType.connected);
+  });
+
+  test('onConnected only emits connection events', () async {
+    final listener = Gamepads.onConnected.first;
+    await platformInterface.platformCallHandler(
+      const MethodCall(
+        'onGamepadConnectionEvent',
+        <String, dynamic>{
+          'gamepadId': '1',
+          'name': 'Test Controller',
+          'type': 'disconnected',
+        },
+      ),
+    );
+    await platformInterface.platformCallHandler(
+      const MethodCall(
+        'onGamepadConnectionEvent',
+        <String, dynamic>{
+          'gamepadId': '2',
+          'name': 'Other Controller',
+          'type': 'connected',
+        },
+      ),
+    );
+    final event = await listener;
+    expect(event.gamepadId, '2');
+    expect(event.type, GamepadConnectionType.connected);
+  });
+
+  test('onDisconnected only emits disconnection events', () async {
+    final listener = Gamepads.onDisconnected.first;
+    await platformInterface.platformCallHandler(
+      const MethodCall(
+        'onGamepadConnectionEvent',
+        <String, dynamic>{
+          'gamepadId': '1',
+          'name': 'Test Controller',
+          'type': 'connected',
+        },
+      ),
+    );
+    await platformInterface.platformCallHandler(
+      const MethodCall(
+        'onGamepadConnectionEvent',
+        <String, dynamic>{
+          'gamepadId': '2',
+          'name': 'Other Controller',
+          'type': 'disconnected',
+        },
+      ),
+    );
+    final event = await listener;
+    expect(event.gamepadId, '2');
+    expect(event.type, GamepadConnectionType.disconnected);
+  });
 }

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/DeviceListener.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/DeviceListener.kt
@@ -4,7 +4,10 @@ import android.hardware.input.InputManager
 import android.util.Log
 import android.view.InputDevice
 
-class DeviceListener(val isGamepadsInputDevice: (device: InputDevice) -> Boolean): InputManager.InputDeviceListener {
+class DeviceListener(
+    val isGamepadsInputDevice: (device: InputDevice) -> Boolean,
+    val onConnectionChanged: (deviceId: Int, name: String, connected: Boolean) -> Unit,
+): InputManager.InputDeviceListener {
     private val devicesLookup: MutableMap<Int, InputDevice> = mutableMapOf()
     private val TAG = "ConnectionListener"
 
@@ -37,12 +40,25 @@ class DeviceListener(val isGamepadsInputDevice: (device: InputDevice) -> Boolean
         return devicesLookup.containsKey(deviceId)
     }
 
+    private fun add(deviceId: Int, device: InputDevice) {
+        if (devicesLookup.put(deviceId, device) == null) {
+            onConnectionChanged(deviceId, device.name, true)
+        }
+    }
+
+    private fun remove(deviceId: Int) {
+        val device = devicesLookup.remove(deviceId)
+        if (device != null) {
+            onConnectionChanged(deviceId, device.name, false)
+        }
+    }
+
     override fun onInputDeviceAdded(deviceId: Int) {
         val device: InputDevice? = InputDevice.getDevice(deviceId)
         if (device != null) {
             if (isGamepadsInputDevice(device)) {
                 Log.i(TAG, "${device.name} passed input device test")
-                devicesLookup[deviceId] = device
+                add(deviceId, device)
             } else {
                 Log.e(TAG, "${device.name} failed input device test")
             }
@@ -50,16 +66,15 @@ class DeviceListener(val isGamepadsInputDevice: (device: InputDevice) -> Boolean
     }
 
     override fun onInputDeviceRemoved(deviceId: Int) {
-        val device: InputDevice? = InputDevice.getDevice(deviceId)
-        devicesLookup.remove(deviceId)
+        remove(deviceId)
     }
 
     override fun onInputDeviceChanged(deviceId: Int) {
         val device: InputDevice? = InputDevice.getDevice(deviceId)
         if (device != null && isGamepadsInputDevice(device)) {
-            devicesLookup[deviceId] = device
+            add(deviceId, device)
         } else {
-            devicesLookup.remove(deviceId)
+            remove(deviceId)
         }
     }
 }

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/DeviceListener.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/DeviceListener.kt
@@ -4,9 +4,14 @@ import android.hardware.input.InputManager
 import android.util.Log
 import android.view.InputDevice
 
+enum class ConnectionEventType(val eventName: String) {
+    CONNECTED("connected"),
+    DISCONNECTED("disconnected"),
+}
+
 class DeviceListener(
     val isGamepadsInputDevice: (device: InputDevice) -> Boolean,
-    val onConnectionChanged: (deviceId: Int, name: String, connected: Boolean) -> Unit,
+    val onConnectionChanged: (deviceId: Int, name: String, type: ConnectionEventType) -> Unit,
 ): InputManager.InputDeviceListener {
     private val devicesLookup: MutableMap<Int, InputDevice> = mutableMapOf()
     private val TAG = "ConnectionListener"
@@ -42,14 +47,14 @@ class DeviceListener(
 
     private fun add(deviceId: Int, device: InputDevice) {
         if (devicesLookup.put(deviceId, device) == null) {
-            onConnectionChanged(deviceId, device.name, true)
+            onConnectionChanged(deviceId, device.name, ConnectionEventType.CONNECTED)
         }
     }
 
     private fun remove(deviceId: Int) {
         val device = devicesLookup.remove(deviceId)
         if (device != null) {
-            onConnectionChanged(deviceId, device.name, false)
+            onConnectionChanged(deviceId, device.name, ConnectionEventType.DISCONNECTED)
         }
     }
 

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
@@ -48,7 +48,7 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     }
   }
 
-  private fun emitConnectionEvent(deviceId: Int, name: String, connected: Boolean) {
+  private fun emitConnectionEvent(deviceId: Int, name: String, type: ConnectionEventType) {
     if (!::channel.isInitialized) {
       return
     }
@@ -57,7 +57,7 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       mapOf(
         "gamepadId" to deviceId.toString(),
         "name" to name,
-        "type" to if (connected) "connected" else "disconnected",
+        "type" to type.eventName,
       )
     )
   }
@@ -104,8 +104,8 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     if (!::devices.isInitialized) {
       devices = DeviceListener(
         isGamepadsInputDevice = { compatibleActivity.isGamepadsInputDevice(it) },
-        onConnectionChanged = { deviceId, name, connected ->
-          emitConnectionEvent(deviceId, name, connected)
+        onConnectionChanged = { deviceId, name, type ->
+          emitConnectionEvent(deviceId, name, type)
         },
       )
       compatibleActivity.registerInputDeviceListener(devices, handler = null)

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
@@ -48,6 +48,20 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
     }
   }
 
+  private fun emitConnectionEvent(deviceId: Int, name: String, connected: Boolean) {
+    if (!::channel.isInitialized) {
+      return
+    }
+    channel.invokeMethod(
+      "onGamepadConnectionEvent",
+      mapOf(
+        "gamepadId" to deviceId.toString(),
+        "name" to name,
+        "type" to if (connected) "connected" else "disconnected",
+      )
+    )
+  }
+
   // FlutterPlugin
   override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
     channel = MethodChannel(flutterPluginBinding.binaryMessenger, "xyz.luan/gamepads")
@@ -82,7 +96,12 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       )
       return
     }
-    devices = DeviceListener { compatibleActivity.isGamepadsInputDevice(it) }
+    devices = DeviceListener(
+      isGamepadsInputDevice = { compatibleActivity.isGamepadsInputDevice(it) },
+      onConnectionChanged = { deviceId, name, connected ->
+        emitConnectionEvent(deviceId, name, connected)
+      },
+    )
     events = EventListener()
     compatibleActivity.registerInputDeviceListener(devices, handler = null)
     compatibleActivity.registerKeyEventHandler { event ->

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
@@ -96,14 +96,21 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
       )
       return
     }
-    devices = DeviceListener(
-      isGamepadsInputDevice = { compatibleActivity.isGamepadsInputDevice(it) },
-      onConnectionChanged = { deviceId, name, connected ->
-        emitConnectionEvent(deviceId, name, connected)
-      },
-    )
+    // The listener is registered with the process-wide InputManager, so it
+    // outlives the activity and must only be registered once. Registering a
+    // new one on every reattach (which happens on every configuration change,
+    // such as a rotation) would report each connection and disconnection once
+    // per registration.
+    if (!::devices.isInitialized) {
+      devices = DeviceListener(
+        isGamepadsInputDevice = { compatibleActivity.isGamepadsInputDevice(it) },
+        onConnectionChanged = { deviceId, name, connected ->
+          emitConnectionEvent(deviceId, name, connected)
+        },
+      )
+      compatibleActivity.registerInputDeviceListener(devices, handler = null)
+    }
     events = EventListener()
-    compatibleActivity.registerInputDeviceListener(devices, handler = null)
     compatibleActivity.registerKeyEventHandler { event ->
       if (devices.containsKey(event.deviceId)) {
         events.onKeyEvent(event, channel)

--- a/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsDarwinPlugin.swift
+++ b/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsDarwinPlugin.swift
@@ -18,6 +18,11 @@ public class GamepadsDarwinPlugin: NSObject, FlutterPlugin {
     let channel: FlutterMethodChannel
     let gamepads = GamepadsListener()
 
+    /// The name each gamepad had when it connected. By the time it
+    /// disconnects its `GCDevice` is usually already gone, and `getName`
+    /// would fall back to "Unknown device".
+    private var gamepadNames = [Int: String]()
+
     init(channel: FlutterMethodChannel) {
         self.channel = channel
         super.init()
@@ -61,9 +66,16 @@ public class GamepadsDarwinPlugin: NSObject, FlutterPlugin {
     }
 
     private func onGamepadConnectionEvent(gamepadId: Int, gamepad: GCExtendedGamepad, connected: Bool) {
+        let name: String
+        if connected {
+            name = getName(gamepad: gamepad)
+            gamepadNames[gamepadId] = name
+        } else {
+            name = gamepadNames.removeValue(forKey: gamepadId) ?? getName(gamepad: gamepad)
+        }
         let arguments: [String: Any] = [
             "gamepadId": String(gamepadId),
-            "name": getName(gamepad: gamepad),
+            "name": name,
             "type": connected ? "connected" : "disconnected",
         ]
         channel.invokeMethod("onGamepadConnectionEvent", arguments: arguments)

--- a/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsDarwinPlugin.swift
+++ b/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsDarwinPlugin.swift
@@ -23,6 +23,7 @@ public class GamepadsDarwinPlugin: NSObject, FlutterPlugin {
         super.init()
 
         self.gamepads.listener = onGamepadEvent
+        self.gamepads.connectionListener = onGamepadConnectionEvent
     }
 
     public static func register(with registrar: FlutterPluginRegistrar) {
@@ -57,6 +58,15 @@ public class GamepadsDarwinPlugin: NSObject, FlutterPlugin {
             ]
             channel.invokeMethod("onGamepadEvent", arguments: arguments)
         }
+    }
+
+    private func onGamepadConnectionEvent(gamepadId: Int, gamepad: GCExtendedGamepad, connected: Bool) {
+        let arguments: [String: Any] = [
+            "gamepadId": String(gamepadId),
+            "name": getName(gamepad: gamepad),
+            "type": connected ? "connected" : "disconnected",
+        ]
+        channel.invokeMethod("onGamepadConnectionEvent", arguments: arguments)
     }
 
     /// Returns a fixed key name for elements whose SF Symbol names are

--- a/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsListener.swift
+++ b/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsListener.swift
@@ -6,6 +6,11 @@ class GamepadsListener {
     var listener: ((Int, GCExtendedGamepad, GCControllerElement) -> Void)?
     var connectionListener: ((Int, GCExtendedGamepad, Bool) -> Void)?
 
+    /// The id each gamepad was given when it connected. Looking the id up
+    /// again on disconnect would return a different one, since removing a
+    /// gamepad shifts the indices of the ones after it.
+    private var gamepadIds: [ObjectIdentifier: Int] = [:]
+
     init() {
         NotificationCenter.default.addObserver(
             self,
@@ -30,6 +35,7 @@ class GamepadsListener {
             if let gamepad = controller.extendedGamepad {
                 gamepads.append(gamepad)
                 let gamepadId = getAndSetPlayerId(of: gamepad)
+                gamepadIds[ObjectIdentifier(gamepad)] = gamepadId
 
                 gamepad.valueChangedHandler = { gamepad, element in
                     if let listener = self.listener {
@@ -44,10 +50,11 @@ class GamepadsListener {
 
     @objc private func joystickDidDisconnect(notification: NSNotification) {
         if let controller = notification.object as? GCController {
-            if let gamepad = controller.extendedGamepad,
-               let gamepadId = gamepads.firstIndex(of: gamepad) {
-                gamepads.remove(at: gamepadId)
-                connectionListener?(gamepadId, gamepad, false)
+            if let gamepad = controller.extendedGamepad {
+                gamepads.removeAll(where: { $0 == gamepad })
+                if let gamepadId = gamepadIds.removeValue(forKey: ObjectIdentifier(gamepad)) {
+                    connectionListener?(gamepadId, gamepad, false)
+                }
             }
         }
     }

--- a/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsListener.swift
+++ b/packages/gamepads_darwin/darwin/gamepads_darwin/Sources/gamepads_darwin/GamepadsListener.swift
@@ -4,6 +4,7 @@ import GameController
 class GamepadsListener {
     var gamepads: [GCExtendedGamepad] = []
     var listener: ((Int, GCExtendedGamepad, GCControllerElement) -> Void)?
+    var connectionListener: ((Int, GCExtendedGamepad, Bool) -> Void)?
 
     init() {
         NotificationCenter.default.addObserver(
@@ -35,13 +36,19 @@ class GamepadsListener {
                         listener(gamepadId, gamepad, element);
                     }
                 }
+
+                connectionListener?(gamepadId, gamepad, true)
             }
         }
     }
- 
+
     @objc private func joystickDidDisconnect(notification: NSNotification) {
         if let controller = notification.object as? GCController {
-            gamepads.removeAll(where: { $0 == controller.extendedGamepad })
+            if let gamepad = controller.extendedGamepad,
+               let gamepadId = gamepads.firstIndex(of: gamepad) {
+                gamepads.remove(at: gamepadId)
+                connectionListener?(gamepadId, gamepad, false)
+            }
         }
     }
 

--- a/packages/gamepads_linux/linux/gamepads_linux_plugin.cc
+++ b/packages/gamepads_linux/linux/gamepads_linux_plugin.cc
@@ -61,6 +61,22 @@ static void emit_gamepad_event(gamepad::GamepadInfo* gamepad,
   }
 }
 
+static void emit_gamepad_connection_event(const std::string& device_id,
+                                          const std::string& name,
+                                          bool connected) {
+  if (channel) {
+    g_autoptr(FlValue) map = fl_value_new_map();
+    fl_value_set_string(map, "gamepadId",
+                        fl_value_new_string(device_id.c_str()));
+    fl_value_set_string(map, "name", fl_value_new_string(name.c_str()));
+    fl_value_set_string(
+        map, "type",
+        fl_value_new_string(connected ? "connected" : "disconnected"));
+    fl_method_channel_invoke_method(channel, "onGamepadConnectionEvent", map,
+                                    nullptr, nullptr, nullptr);
+  }
+}
+
 static void respond_not_found(FlMethodCall* method_call) {
   g_autoptr(FlMethodResponse) response =
       FL_METHOD_RESPONSE(fl_method_not_implemented_response_new());
@@ -131,9 +147,10 @@ void event_loop_start() {
       &keep_reading_events,
       [](const connection_listener::ConnectionEvent& event) {
         std::string key = event.device_id;
-        std::optional<gamepad::GamepadInfo> existingGamepad = gamepads[key];
+        auto existingGamepad = gamepads.find(key);
         if (event.type == connection_listener::ConnectionEventType::CONNECTED) {
-          if (existingGamepad && existingGamepad->alive) {
+          if (existingGamepad != gamepads.end() &&
+              existingGamepad->second.alive) {
             std::cout << "Existing gamepad found; skipping" << std::endl;
             return;
           }
@@ -149,14 +166,17 @@ void event_loop_start() {
           std::cout << "Gamepad connected " << key << " - " << info->name
                     << std::endl;
           gamepads[key] = *info;
+          emit_gamepad_connection_event(key, info->name, true);
 
           std::thread input_thread(process_connection_event, &gamepads[key]);
           input_thread.detach();
         } else {
           std::cout << "Gamepad disconnected " << key << std::endl;
-          if (existingGamepad) {
-            gamepads[key].alive = false;
-            gamepads.erase(key);
+          if (existingGamepad != gamepads.end()) {
+            const std::string name = existingGamepad->second.name;
+            existingGamepad->second.alive = false;
+            gamepads.erase(existingGamepad);
+            emit_gamepad_connection_event(key, name, false);
           }
         }
       });

--- a/packages/gamepads_platform_interface/lib/api/gamepad_connection_event.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_connection_event.dart
@@ -1,0 +1,47 @@
+/// Whether a gamepad became available or unavailable.
+enum GamepadConnectionType {
+  /// The gamepad was plugged in or paired and can now fire events.
+  connected,
+
+  /// The gamepad was unplugged or unpaired and will not fire any more events.
+  disconnected,
+}
+
+/// Represents a gamepad controller being connected to or disconnected from
+/// the device.
+class GamepadConnectionEvent {
+  /// The id of the gamepad controller that was connected or disconnected.
+  ///
+  /// It matches the id reported by `listGamepads` and the `gamepadId` of the
+  /// events fired by that controller.
+  final String gamepadId;
+
+  /// A user-facing, platform-dependant name for the gamepad controller.
+  final String name;
+
+  /// Whether the gamepad was connected or disconnected.
+  final GamepadConnectionType type;
+
+  GamepadConnectionEvent({
+    required this.gamepadId,
+    required this.name,
+    required this.type,
+  });
+
+  @override
+  String toString() {
+    return '[$gamepadId] $name: ${type.name}';
+  }
+
+  factory GamepadConnectionEvent.parse(Map<dynamic, dynamic> map) {
+    final gamepadId = map['gamepadId'] as String;
+    final name = map['name'] as String;
+    final type = GamepadConnectionType.values.byName(map['type'] as String);
+
+    return GamepadConnectionEvent(
+      gamepadId: gamepadId,
+      name: name,
+      type: type,
+    );
+  }
+}

--- a/packages/gamepads_platform_interface/lib/api/gamepad_connection_event.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_connection_event.dart
@@ -1,5 +1,5 @@
 /// Whether a gamepad became available or unavailable.
-enum GamepadConnectionType {
+enum GamepadConnectionEventType {
   /// The gamepad was plugged in or paired and can now fire events.
   connected,
 
@@ -20,7 +20,7 @@ class GamepadConnectionEvent {
   final String name;
 
   /// Whether the gamepad was connected or disconnected.
-  final GamepadConnectionType type;
+  final GamepadConnectionEventType type;
 
   GamepadConnectionEvent({
     required this.gamepadId,
@@ -36,7 +36,9 @@ class GamepadConnectionEvent {
   factory GamepadConnectionEvent.parse(Map<dynamic, dynamic> map) {
     final gamepadId = map['gamepadId'] as String;
     final name = map['name'] as String;
-    final type = GamepadConnectionType.values.byName(map['type'] as String);
+    final type = GamepadConnectionEventType.values.byName(
+      map['type'] as String,
+    );
 
     return GamepadConnectionEvent(
       gamepadId: gamepadId,

--- a/packages/gamepads_platform_interface/lib/gamepads_platform_interface.dart
+++ b/packages/gamepads_platform_interface/lib/gamepads_platform_interface.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+import 'package:gamepads_platform_interface/api/gamepad_connection_event.dart';
 import 'package:gamepads_platform_interface/api/gamepad_controller.dart';
 import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 import 'package:gamepads_platform_interface/method_channel_gamepads_platform_interface.dart';
@@ -17,10 +21,36 @@ abstract class GamepadsPlatformInterface extends PlatformInterface {
   static GamepadsPlatformInterface instance =
       MethodChannelGamepadsPlatformInterface();
 
+  final StreamController<GamepadEvent> _gamepadEventsStreamController =
+      StreamController<GamepadEvent>.broadcast();
+
+  final StreamController<GamepadConnectionEvent>
+  _gamepadConnectionEventsStreamController =
+      StreamController<GamepadConnectionEvent>.broadcast();
+
   Future<List<GamepadController>> listGamepads();
 
-  Stream<GamepadEvent> get gamepadEventsStream;
+  Stream<GamepadEvent> get gamepadEventsStream =>
+      _gamepadEventsStreamController.stream;
 
   Stream<GamepadEvent> eventsByGamepad(String gamepadId) =>
       gamepadEventsStream.where((event) => event.gamepadId == gamepadId);
+
+  /// A stream of gamepads being connected to and disconnected from the device.
+  Stream<GamepadConnectionEvent> get gamepadConnectionEventsStream =>
+      _gamepadConnectionEventsStreamController.stream;
+
+  void emitGamepadEvent(GamepadEvent event) {
+    _gamepadEventsStreamController.add(event);
+  }
+
+  void emitGamepadConnectionEvent(GamepadConnectionEvent event) {
+    _gamepadConnectionEventsStreamController.add(event);
+  }
+
+  @mustCallSuper
+  Future<void> dispose() async {
+    await _gamepadEventsStreamController.close();
+    await _gamepadConnectionEventsStreamController.close();
+  }
 }

--- a/packages/gamepads_platform_interface/lib/method_channel_gamepads_platform_interface.dart
+++ b/packages/gamepads_platform_interface/lib/method_channel_gamepads_platform_interface.dart
@@ -1,7 +1,5 @@
-import 'dart:async';
-
-import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:gamepads_platform_interface/api/gamepad_connection_event.dart';
 import 'package:gamepads_platform_interface/api/gamepad_controller.dart';
 import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
@@ -29,22 +27,8 @@ class MethodChannelGamepadsPlatformInterface extends GamepadsPlatformInterface {
     switch (call.method) {
       case 'onGamepadEvent':
         emitGamepadEvent(GamepadEvent.parse(call.args));
+      case 'onGamepadConnectionEvent':
+        emitGamepadConnectionEvent(GamepadConnectionEvent.parse(call.args));
     }
-  }
-
-  void emitGamepadEvent(GamepadEvent event) {
-    _gamepadEventsStreamController.add(event);
-  }
-
-  final StreamController<GamepadEvent> _gamepadEventsStreamController =
-      StreamController<GamepadEvent>.broadcast();
-
-  @override
-  Stream<GamepadEvent> get gamepadEventsStream =>
-      _gamepadEventsStreamController.stream;
-
-  @mustCallSuper
-  Future<void> dispose() async {
-    _gamepadEventsStreamController.close();
   }
 }

--- a/packages/gamepads_web/lib/gamepads_web.dart
+++ b/packages/gamepads_web/lib/gamepads_web.dart
@@ -1,8 +1,8 @@
 import 'dart:async';
 import 'dart:js_interop';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter_web_plugins/flutter_web_plugins.dart';
+import 'package:gamepads_platform_interface/api/gamepad_connection_event.dart';
 import 'package:gamepads_platform_interface/api/gamepad_controller.dart';
 import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
@@ -88,6 +88,14 @@ class GamepadsWeb extends GamepadsPlatformInterface {
       'gamepadconnected',
       (web.Event event) {
         _gamepadCount++;
+        final jsGamepad = (event as web.GamepadEvent).gamepad;
+        emitGamepadConnectionEvent(
+          GamepadConnectionEvent(
+            gamepadId: jsGamepad.index.toString(),
+            name: jsGamepad.id,
+            type: GamepadConnectionType.connected,
+          ),
+        );
         if (_gamepadCount == 1) {
           // The game pad state for web is not event driven. We need to
           // query the game pad state by ourself.
@@ -110,6 +118,13 @@ class GamepadsWeb extends GamepadsPlatformInterface {
         final gamepadId = jsGamepad.index.toString();
         _gamepadIds.remove(gamepadId);
         _lastGamepadStates.remove(gamepadId);
+        emitGamepadConnectionEvent(
+          GamepadConnectionEvent(
+            gamepadId: gamepadId,
+            name: jsGamepad.id,
+            type: GamepadConnectionType.disconnected,
+          ),
+        );
         if (_gamepadCount == 0) {
           _gamepadPollingTimer?.cancel();
         }
@@ -127,21 +142,5 @@ class GamepadsWeb extends GamepadsPlatformInterface {
   Future<List<GamepadController>> listGamepads() async {
     controllers = getGamepads(this);
     return controllers!;
-  }
-
-  void emitGamepadEvent(GamepadEvent event) {
-    _gamepadEventsStreamController.add(event);
-  }
-
-  final StreamController<GamepadEvent> _gamepadEventsStreamController =
-      StreamController<GamepadEvent>.broadcast();
-
-  @override
-  Stream<GamepadEvent> get gamepadEventsStream =>
-      _gamepadEventsStreamController.stream;
-
-  @mustCallSuper
-  Future<void> dispose() async {
-    _gamepadEventsStreamController.close();
   }
 }

--- a/packages/gamepads_web/lib/gamepads_web.dart
+++ b/packages/gamepads_web/lib/gamepads_web.dart
@@ -93,7 +93,7 @@ class GamepadsWeb extends GamepadsPlatformInterface {
           GamepadConnectionEvent(
             gamepadId: jsGamepad.index.toString(),
             name: jsGamepad.id,
-            type: GamepadConnectionType.connected,
+            type: GamepadConnectionEventType.connected,
           ),
         );
         if (_gamepadCount == 1) {
@@ -122,7 +122,7 @@ class GamepadsWeb extends GamepadsPlatformInterface {
           GamepadConnectionEvent(
             gamepadId: gamepadId,
             name: jsGamepad.id,
-            type: GamepadConnectionType.disconnected,
+            type: GamepadConnectionEventType.disconnected,
           ),
         );
         if (_gamepadCount == 0) {

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -205,8 +205,12 @@ void Gamepads::on_gamepad_disconnected(IGameInputDevice* device) {
   std::string removeId = AppLocalDeviceIdToString(info->deviceId);
   std::cout << "Gamepad disconnected: " << removeId << std::endl;
   GamepadData* removeGp = nullptr;
+  std::string removeName;
   for (auto gp : this->gamepads) {
     if (gp->id == removeId) {
+      // Copy the name before signalling the thread; once stop_thread is set
+      // the thread may exit and free the gamepad at any moment.
+      removeName = gp->name;
       gp->stop_thread = true;
       removeGp = gp;
       break;
@@ -214,10 +218,9 @@ void Gamepads::on_gamepad_disconnected(IGameInputDevice* device) {
   }
   // Remove the gamepad from list. The thread will free up memory.
   if (removeGp != nullptr) {
-    const std::string name = removeGp->name;
     this->gamepads.remove(removeGp);
     if (connection_emitter.has_value()) {
-      (*connection_emitter)(removeId, name, false);
+      (*connection_emitter)(removeId, removeName, false);
     }
   }
 }

--- a/packages/gamepads_windows/windows/gamepad.cpp
+++ b/packages/gamepads_windows/windows/gamepad.cpp
@@ -187,6 +187,10 @@ void Gamepads::on_gamepad_connected(IGameInputDevice* device) {
   std::cout << "Gamepad connected: " << gp->id << " : " << gp->name
             << std::endl;
 
+  if (connection_emitter.has_value()) {
+    (*connection_emitter)(gp->id, gp->name, true);
+  }
+
   std::thread read_thread(
       [this, gp, device]() { this->read_gamepad(gp, device); });
   read_thread.detach();
@@ -210,7 +214,11 @@ void Gamepads::on_gamepad_disconnected(IGameInputDevice* device) {
   }
   // Remove the gamepad from list. The thread will free up memory.
   if (removeGp != nullptr) {
+    const std::string name = removeGp->name;
     this->gamepads.remove(removeGp);
+    if (connection_emitter.has_value()) {
+      (*connection_emitter)(removeId, name, false);
+    }
   }
 }
 

--- a/packages/gamepads_windows/windows/gamepad.h
+++ b/packages/gamepads_windows/windows/gamepad.h
@@ -39,6 +39,9 @@ class Gamepads {
  public:
   std::optional<std::function<void(GamepadData* gamepad, const Event& event)>>
       event_emitter;
+  std::optional<std::function<
+      void(const std::string& id, const std::string& name, bool connected)>>
+      connection_emitter;
   void init();
   void stop();
   std::list<GamepadData*> get_gamepads();

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
@@ -35,6 +35,10 @@ GamepadsWindowsPlugin::GamepadsWindowsPlugin(
   gamepads.event_emitter = [&](GamepadData* gamepad, const Event& event) {
     this->emit_gamepad_event(gamepad, event);
   };
+  gamepads.connection_emitter = [&](const std::string& id,
+                                    const std::string& name, bool connected) {
+    this->emit_gamepad_connection_event(id, name, connected);
+  };
   gamepads.init();
 }
 
@@ -81,6 +85,23 @@ void GamepadsWindowsPlugin::emit_gamepad_event(GamepadData* gamepad,
     map[flutter::EncodableValue("productId")] =
         flutter::EncodableValue(gamepad->product_id);
     _channel->InvokeMethod("onGamepadEvent",
+                           std::make_unique<flutter::EncodableValue>(
+                               flutter::EncodableValue(map)));
+  }
+}
+
+void GamepadsWindowsPlugin::emit_gamepad_connection_event(
+    const std::string& id,
+    const std::string& name,
+    bool connected) {
+  auto _channel = this->channel.get();
+  if (_channel) {
+    flutter::EncodableMap map;
+    map[flutter::EncodableValue("gamepadId")] = flutter::EncodableValue(id);
+    map[flutter::EncodableValue("name")] = flutter::EncodableValue(name);
+    map[flutter::EncodableValue("type")] =
+        flutter::EncodableValue(connected ? "connected" : "disconnected");
+    _channel->InvokeMethod("onGamepadConnectionEvent",
                            std::make_unique<flutter::EncodableValue>(
                                flutter::EncodableValue(map)));
   }

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.h
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.h
@@ -32,6 +32,10 @@ class GamepadsWindowsPlugin : public flutter::Plugin {
       std::unique_ptr<flutter::MethodResult<flutter::EncodableValue>> result);
 
   void emit_gamepad_event(GamepadData* gamepad, const Event& event);
+
+  void emit_gamepad_connection_event(const std::string& id,
+                                     const std::string& name,
+                                     bool connected);
 };
 
 }  // namespace gamepads_windows


### PR DESCRIPTION
Closes #131

Every platform already detected gamepads being plugged in and unplugged, but kept it internal. This surfaces it to Dart.

## API

```dart
Gamepads.connectionEvents  // Stream<GamepadConnectionEvent>, both kinds
Gamepads.onConnected       // filtered to connected
Gamepads.onDisconnected    // filtered to disconnected
```

The issue suggested `Stream<GamepadController>`. Events carry a `GamepadConnectionEvent` with `gamepadId`, `name` and a `GamepadConnectionType` instead, because a `GamepadController` is a resource that subscribes on construction and must be disposed, so emitting one per event, especially per disconnect, would either leak subscriptions or hand back an already-dead object. The event mirrors `GamepadEvent`, and its `gamepadId` matches the id from `list()` and from input events.

## Platform interface

The event `StreamController` plumbing was duplicated in `MethodChannelGamepadsPlatformInterface` and `GamepadsWeb`. Both streams now live in `GamepadsPlatformInterface` with `emitGamepadEvent` / `emitGamepadConnectionEvent` and a `dispose` that closes both. `gamepadEventsStream` went from abstract to concrete, which is backwards compatible for anyone overriding it.

## Natives

All five send a new `onGamepadConnectionEvent` method call from hooks they already had:

- **iOS**: the `// Optional: send disconnection event` TODO is now done.
- **macOS**: `GamepadsListener` gained a `connectionListener`. `joystickDidDisconnect` now captures the index before removing, since that index is the id reported to Dart.
- **Android**: `DeviceListener` got `add`/`remove` helpers that emit only on real transitions, so `onInputDeviceChanged` does not double-report. Removal reads the name from the cache, since `InputDevice.getDevice` returns null once the device is gone.
- **Linux**: the connect/disconnect branch used `gamepads[key]`, which default-inserts, so `if (existingGamepad)` was always true; switched to `find` so disconnects only fire for tracked devices and carry the real name.
- **Windows**: a `connection_emitter` alongside `event_emitter`. The name is copied before the read thread frees the `GamepadData`.

## Verification

`flutter analyze` clean, all 85 tests pass, including three new ones covering `connectionEvents`, `onConnected` and `onDisconnected` filtering. Web and Android compile against these sources (`flutter build web` and `flutter build apk --debug` in a scratch app with path overrides).

The Swift files parse (`swiftc -parse`) but were **not** type-checked or built, since Xcode is not fully installed on the machine this was written on, and the Linux and Windows C++ could not be compiled from macOS. Those five native files are reviewed but unbuilt and want a CI or local check.

Also updates the README with a connection-events section, and the example app to log connects/disconnects and refresh its list from them.
