### PR TITLE
feat: Add vendorId and productId to Gamepads.list()

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ The `list` method will list all currently connected gamepads:
 ```
 
 This uses the data class `GamepadController`, which has an `id` and a user-facing `name`.
+It also reports `vendorId` and `productId` where the platform provides them, so you can
+identify a connected gamepad (e.g. "Sony DualSense") before it sends any input. These are
+`null` on macOS and iOS, where `GCController` does not expose vendor/product ids.
 
 Listen to `normalizedEvents` for gamepad input with consistent
 button/axis names and value ranges across all platforms:
@@ -157,7 +160,9 @@ Stick conventions: Left/Down = -1, Right/Up = +1.
 
 **iOS / macOS** — Uses the GCController API. Button and axis
 names are SF Symbols strings (e.g. `a.circle`, `l.joystick`),
-which the normalizer matches by pattern.
+which the normalizer matches by pattern. `GCController` does
+not expose USB identifiers, so `vendorId` and `productId` are
+always `null` on these platforms.
 
 **Android** — Uses `KeyEvent` and `MotionEvent` with
 platform-defined key codes (e.g. `KEYCODE_BUTTON_A`,

--- a/packages/gamepads/example/lib/main.dart
+++ b/packages/gamepads/example/lib/main.dart
@@ -173,9 +173,7 @@ class _MyHomePageState extends State<MyHomePage> {
                 const CircularProgressIndicator()
               else ...[
                 for (final gamepad in _gamepads) ...[
-                  Text(
-                    '${gamepad.id} - ${gamepad.name}',
-                  ),
+                  Text(_describeGamepad(gamepad)),
                 ],
               ],
             ],
@@ -183,6 +181,20 @@ class _MyHomePageState extends State<MyHomePage> {
         ),
       ),
     );
+  }
+
+  String _describeGamepad(GamepadController gamepad) {
+    final vendorId = gamepad.vendorId;
+    final productId = gamepad.productId;
+
+    if (vendorId == null || productId == null) {
+      return '${gamepad.id} - ${gamepad.name}';
+    }
+
+    final vendor = vendorId.toRadixString(16).padLeft(4, '0');
+    final product = productId.toRadixString(16).padLeft(4, '0');
+
+    return '${gamepad.id} - ${gamepad.name} ($vendor:$product)';
   }
 
   Widget _buildEventTile(_EventEntry entry) {

--- a/packages/gamepads/test/gamepads_test.dart
+++ b/packages/gamepads/test/gamepads_test.dart
@@ -43,6 +43,30 @@ void main() {
     expect(popLastCall().method, 'listGamepads');
   });
 
+  test('parses vendorId and productId', () async {
+    final controller = GamepadController.parse(<String, dynamic>{
+      'id': '1',
+      'name': 'Test Gamepad',
+      'vendorId': 0x054c,
+      'productId': 0x0ce6,
+    }, platformInterface);
+    addTearDown(controller.dispose);
+
+    expect(controller.vendorId, 0x054c);
+    expect(controller.productId, 0x0ce6);
+  });
+
+  test('leaves vendorId and productId null when absent', () async {
+    final controller = GamepadController.parse(<String, dynamic>{
+      'id': '1',
+      'name': 'Test Gamepad',
+    }, platformInterface);
+    addTearDown(controller.dispose);
+
+    expect(controller.vendorId, isNull);
+    expect(controller.productId, isNull);
+  });
+
   test('can listen to events through platform interface', () async {
     final listener = Gamepads.events.first;
     final millis = DateTime.now().millisecondsSinceEpoch;

--- a/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
+++ b/packages/gamepads_android/android/src/main/kotlin/org/flame_engine/gamepads_android/GamepadsAndroidPlugin.kt
@@ -34,14 +34,16 @@ class GamepadsAndroidPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private var motionDecorView: View? = null
   private var genericMotionListener: View.OnGenericMotionListener? = null
 
-  private fun listGamepads(): List<Map<String, String>>  {
+  private fun listGamepads(): List<Map<String, Any?>>  {
     if (!::devices.isInitialized) {
       return emptyList()
     }
     return devices.getDevices().map { device ->
       mapOf(
         "id" to device.key.toString(),
-        "name" to device.value.name
+        "name" to device.value.name,
+        "vendorId" to device.value.vendorId,
+        "productId" to device.value.productId
       )
     }
   }

--- a/packages/gamepads_linux/linux/gamepads_linux_plugin.cc
+++ b/packages/gamepads_linux/linux/gamepads_linux_plugin.cc
@@ -86,6 +86,10 @@ static void gamepads_linux_plugin_handle_method_call(
                    fl_value_new_string(device_id.c_str()));
       fl_value_set(map, fl_value_new_string("name"),
                    fl_value_new_string(gamepad.name.c_str()));
+      fl_value_set(map, fl_value_new_string("vendorId"),
+                   fl_value_new_int(gamepad.vendor_id));
+      fl_value_set(map, fl_value_new_string("productId"),
+                   fl_value_new_int(gamepad.product_id));
       fl_value_append(list, map);
     }
     respond(method_call, list);

--- a/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
+++ b/packages/gamepads_platform_interface/lib/api/gamepad_controller.dart
@@ -19,6 +19,16 @@ class GamepadController {
   /// A user-facing, platform-dependant name for the gamepad controller.
   final String name;
 
+  /// The USB vendor ID of the controller, if available.
+  ///
+  /// Always `null` on macOS and iOS, where `GCController` does not expose it.
+  final int? vendorId;
+
+  /// The USB product ID of the controller, if available.
+  ///
+  /// Always `null` on macOS and iOS, where `GCController` does not expose it.
+  final int? productId;
+
   final state = GamepadState();
 
   StreamSubscription<GamepadEvent>? _subscription;
@@ -27,6 +37,8 @@ class GamepadController {
     required this.id,
     required this.name,
     required GamepadsPlatformInterface plugin,
+    this.vendorId,
+    this.productId,
   }) {
     _subscription = plugin.eventsByGamepad(id).listen(state.update);
   }
@@ -37,7 +49,15 @@ class GamepadController {
   ) {
     final id = map['id'] as String;
     final name = map['name'] as String;
-    return GamepadController(id: id, name: name, plugin: plugin);
+    final vendorId = map['vendorId'] as int?;
+    final productId = map['productId'] as int?;
+    return GamepadController(
+      id: id,
+      name: name,
+      plugin: plugin,
+      vendorId: vendorId,
+      productId: productId,
+    );
   }
 
   /// Stops listening for new inputs.

--- a/packages/gamepads_web/lib/gamepads_web.dart
+++ b/packages/gamepads_web/lib/gamepads_web.dart
@@ -7,7 +7,7 @@ import 'package:gamepads_platform_interface/api/gamepad_controller.dart';
 import 'package:gamepads_platform_interface/api/gamepad_event.dart';
 import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
 import 'package:gamepads_web/src/gamepad_detector.dart'
-    show getGamepadList, getGamepads;
+    show getGamepadList, getGamepads, parseGamepadIds;
 import 'package:web/web.dart' as web;
 
 class _GamepadState {
@@ -17,36 +17,6 @@ class _GamepadState {
 
   final List<double?> keyStates;
   final List<double> axesStates;
-}
-
-/// Parses vendor/product IDs from the Web Gamepad API id string.
-///
-/// Common formats:
-/// - "Xbox 360 Controller (Vendor: 045e Product: 028e)"
-/// - "045e-028e-Xbox 360 Controller"
-({int? vendorId, int? productId}) _parseGamepadIds(String id) {
-  // Try "Vendor: XXXX Product: XXXX" format
-  final vendorMatch = RegExp(r'Vendor:\s*([0-9a-fA-F]{4})').firstMatch(id);
-  final productMatch = RegExp(r'Product:\s*([0-9a-fA-F]{4})').firstMatch(id);
-  if (vendorMatch != null && productMatch != null) {
-    return (
-      vendorId: int.parse(vendorMatch.group(1)!, radix: 16),
-      productId: int.parse(productMatch.group(1)!, radix: 16),
-    );
-  }
-
-  // Try "XXXX-XXXX-Name" format
-  final dashMatch = RegExp(
-    '^([0-9a-fA-F]{4})-([0-9a-fA-F]{4})',
-  ).firstMatch(id);
-  if (dashMatch != null) {
-    return (
-      vendorId: int.parse(dashMatch.group(1)!, radix: 16),
-      productId: int.parse(dashMatch.group(2)!, radix: 16),
-    );
-  }
-
-  return (vendorId: null, productId: null);
 }
 
 /// A web implementation of the GamepadsWebPlatform of the GamepadsWeb plugin.
@@ -65,7 +35,7 @@ class GamepadsWeb extends GamepadsPlatformInterface {
       final gamepadId = gamepad.index.toString();
       final ids = _gamepadIds.putIfAbsent(
         gamepadId,
-        () => _parseGamepadIds(gamepad.id),
+        () => parseGamepadIds(gamepad.id),
       );
       final _GamepadState lastState;
       if (_lastGamepadStates.containsKey(gamepadId) &&

--- a/packages/gamepads_web/lib/src/gamepad_detector.dart
+++ b/packages/gamepads_web/lib/src/gamepad_detector.dart
@@ -5,17 +5,50 @@ import 'package:gamepads_platform_interface/gamepads_platform_interface.dart';
 import 'package:web/web.dart';
 
 List<GamepadController> getGamepads(GamepadsPlatformInterface plugin) {
-  return getGamepadList()
-      .map(
-        (gamepad) => GamepadController(
-          id: gamepad.index.toString(),
-          name: gamepad.id,
-          plugin: plugin,
-        ),
-      )
-      .toList();
+  return getGamepadList().map(
+    (gamepad) {
+      final ids = parseGamepadIds(gamepad.id);
+      return GamepadController(
+        id: gamepad.index.toString(),
+        name: gamepad.id,
+        plugin: plugin,
+        vendorId: ids.vendorId,
+        productId: ids.productId,
+      );
+    },
+  ).toList();
 }
 
 List<Gamepad> getGamepadList() {
   return window.navigator.getGamepads().toDart.whereType<Gamepad>().toList();
+}
+
+/// Parses vendor/product IDs from the Web Gamepad API id string.
+///
+/// Common formats:
+/// - "Xbox 360 Controller (Vendor: 045e Product: 028e)"
+/// - "045e-028e-Xbox 360 Controller"
+({int? vendorId, int? productId}) parseGamepadIds(String id) {
+  // Try "Vendor: XXXX Product: XXXX" format
+  final vendorMatch = RegExp(r'Vendor:\s*([0-9a-fA-F]{4})').firstMatch(id);
+  final productMatch = RegExp(r'Product:\s*([0-9a-fA-F]{4})').firstMatch(id);
+  if (vendorMatch != null && productMatch != null) {
+    return (
+      vendorId: int.parse(vendorMatch.group(1)!, radix: 16),
+      productId: int.parse(productMatch.group(1)!, radix: 16),
+    );
+  }
+
+  // Try "XXXX-XXXX-Name" format
+  final dashMatch = RegExp(
+    '^([0-9a-fA-F]{4})-([0-9a-fA-F]{4})',
+  ).firstMatch(id);
+  if (dashMatch != null) {
+    return (
+      vendorId: int.parse(dashMatch.group(1)!, radix: 16),
+      productId: int.parse(dashMatch.group(2)!, radix: 16),
+    );
+  }
+
+  return (vendorId: null, productId: null);
 }

--- a/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
+++ b/packages/gamepads_windows/windows/gamepads_windows_plugin.cpp
@@ -52,6 +52,10 @@ void GamepadsWindowsPlugin::HandleMethodCall(
       map[flutter::EncodableValue("id")] = flutter::EncodableValue(gamepad->id);
       map[flutter::EncodableValue("name")] =
           flutter::EncodableValue(gamepad->name);
+      map[flutter::EncodableValue("vendorId")] =
+          flutter::EncodableValue(gamepad->vendor_id);
+      map[flutter::EncodableValue("productId")] =
+          flutter::EncodableValue(gamepad->product_id);
       list.push_back(flutter::EncodableValue(map));
     }
     result->Success(flutter::EncodableValue(list));


### PR DESCRIPTION
## Problem

`Gamepads.list()` returns a `GamepadController` with an id and a name, but no 
stable way to recognize a specific physical gamepad.
`GamepadEvent` already carries `vendorId` and `productId`, so those ids only 
become available on the first input event.

`name` could be used, but it's platform-dependent and not guaranteed to be 
stable.

The ids are already available natively: `gamepad.vendor_id` on Linux, 
`gamepad->vendor_id` on Windows, `device.vendorId` on Android.

## Change

- `GamepadController` gains `vendorId` and `productId`, both `int?`, read in
  `GamepadController.parse` the same way `GamepadEvent.parse` already reads
  them.
- Each native `listGamepads` handler now includes `vendorId`/`productId` in
  the map it returns.
- macOS and iOS are untouched: `GCController` does not expose a vendor/product 
  id. `vendorId`/`productId` are `null` there, exactly as `GamepadEvent`.
- Added two tests in `packages/gamepads/test/gamepads_test.dart`:
  `GamepadController.parse` reads both ids when present, and leaves them
  `null` when the keys are absent.
- Documented the new fields in `GamepadController`'s doc comments and added
  a short note to the README's "Getting Started" section.
- The example app's gamepad list now shows the ids when they're available,
  rendering `id - name (054c:0ce6)`.

## Verification

- `dart analyze packages/gamepads_platform_interface packages/gamepads_web
  packages/gamepads`: clean, no issues.
- `flutter test` in `packages/gamepads`: all 82 tests pass, including the two
  new ones.
- `dart format` applied to all changed Dart files.
- Built a throwaway Flutter app with a `main.dart` that calls
  `Gamepads.list()` and reads `vendorId`/`productId` off the result:
  - `flutter build web`: succeeded.
  - `flutter build apk --debug`: succeeded.

## Related Issues

Closes #134.