### PR TITLE
docs: Document Gamepads.list() snapshot after disconnect (#20)

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,12 +50,16 @@ new connections.
 
 ## Getting Started
 
-The `list` method will list all currently connected gamepads:
+The `list` method returns a snapshot of currently connected gamepads:
 
 ```dart
   final gamepads = await Gamepads.list();
   // ...
 ```
+
+Unplug a pad and call `list()` again — it is not kept in the result.
+On iOS and macOS the name can be `Unknown device` when `GCController`
+does not expose vendor or product strings.
 
 This uses the data class `GamepadController`, which has an `id` and a user-facing `name`.
 It also reports `vendorId` and `productId` where the platform provides them, so you can

--- a/packages/gamepads/lib/src/gamepads.dart
+++ b/packages/gamepads/lib/src/gamepads.dart
@@ -31,6 +31,13 @@ class Gamepads {
     _normalizedEvents = null;
   }
 
+  /// Currently connected gamepads.
+  ///
+  /// This is a snapshot. Connect or unplug a pad and call [list] again;
+  /// a disconnected pad is not kept in the result.
+  ///
+  /// On iOS and macOS, [GamepadController.name] can be `Unknown device`
+  /// when `GCController` does not expose vendor or product strings.
   static Future<List<GamepadController>> list() => _platform.listGamepads();
 
   static Stream<GamepadEvent> get events => _platform.gamepadEventsStream;


### PR DESCRIPTION
Gamepads.list() is a snapshot of pads that are connected right now. I documented
that a disconnected pad is not kept in the next list() result, and that Apple
platforms can report the name as Unknown device when GCController has no vendor
or product strings.

Fixes #20
