### PR TITLE
feat: Simplified opt-in to directional focus control

### DIFF
--- a/packages/flutter_gamepads/README.md
+++ b/packages/flutter_gamepads/README.md
@@ -154,6 +154,11 @@ The bindings can customized via the `shortcuts` parameter. It is not limited to 
 above. Any class that inherits from the `Intent` base class can be used as the emitted intent
 for a gamepad activator (button or axis).
 
+If you prefer to use directional focus over sequential focus you can set `shortcuts` to
+`GamepadShortcuts.directionalTraversal`. This may be less robust than the default sequential
+focus traversal bindings, but each app has its own situation and only way to find out is
+to test what works for your case.
+
 
 ### Flame specific guidance
 

--- a/packages/flutter_gamepads/lib/flutter_gamepads.dart
+++ b/packages/flutter_gamepads/lib/flutter_gamepads.dart
@@ -1,3 +1,4 @@
 export 'src/api/gamepad_activator.dart';
+export 'src/api/gamepad_shortcuts.dart';
 export 'src/gamepad_control.dart';
 export 'src/gamepad_interceptor.dart';

--- a/packages/flutter_gamepads/lib/src/api/gamepad_shortcuts.dart
+++ b/packages/flutter_gamepads/lib/src/api/gamepad_shortcuts.dart
@@ -1,0 +1,58 @@
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gamepads/flutter_gamepads.dart';
+
+class GamepadShortcuts {
+  /// A shortcuts configuration for [GamepadControl] using sequential focus
+  /// intents.
+  static const Map<GamepadActivator, Intent> sequentialTraversal = {
+    GamepadActivatorButton.a(): ActivateIntent(),
+    GamepadActivatorButton.b(): DismissIntent(),
+    GamepadActivatorButton.dpadUp(): PreviousFocusIntent(),
+    GamepadActivatorButton.dpadLeft(): PreviousFocusIntent(),
+    GamepadActivatorButton.dpadDown(): NextFocusIntent(),
+    GamepadActivatorButton.dpadRight(): NextFocusIntent(),
+    GamepadActivatorAxis.rightStickUp(): ScrollIntent(
+      direction: AxisDirection.up,
+    ),
+    GamepadActivatorAxis.rightStickLeft(): ScrollIntent(
+      direction: AxisDirection.left,
+    ),
+    GamepadActivatorAxis.rightStickDown(): ScrollIntent(
+      direction: AxisDirection.down,
+    ),
+    GamepadActivatorAxis.rightStickRight(): ScrollIntent(
+      direction: AxisDirection.right,
+    ),
+  };
+
+  /// A shortcuts configuration for [GamepadControl] using directional focus
+  /// intents.
+  static const Map<GamepadActivator, Intent> directionalTraversal = {
+    GamepadActivatorButton.a(): ActivateIntent(),
+    GamepadActivatorButton.b(): DismissIntent(),
+    GamepadActivatorButton.dpadUp(): DirectionalFocusIntent(
+      TraversalDirection.up,
+    ),
+    GamepadActivatorButton.dpadLeft(): DirectionalFocusIntent(
+      TraversalDirection.left,
+    ),
+    GamepadActivatorButton.dpadDown(): DirectionalFocusIntent(
+      TraversalDirection.down,
+    ),
+    GamepadActivatorButton.dpadRight(): DirectionalFocusIntent(
+      TraversalDirection.right,
+    ),
+    GamepadActivatorAxis.rightStickUp(): ScrollIntent(
+      direction: AxisDirection.up,
+    ),
+    GamepadActivatorAxis.rightStickLeft(): ScrollIntent(
+      direction: AxisDirection.left,
+    ),
+    GamepadActivatorAxis.rightStickDown(): ScrollIntent(
+      direction: AxisDirection.down,
+    ),
+    GamepadActivatorAxis.rightStickRight(): ScrollIntent(
+      direction: AxisDirection.right,
+    ),
+  };
+}

--- a/packages/flutter_gamepads/lib/src/gamepad_control.dart
+++ b/packages/flutter_gamepads/lib/src/gamepad_control.dart
@@ -48,29 +48,17 @@ class GamepadControl extends StatefulWidget {
     /// Configures the bindings between Gamepad activator (button or axis)
     /// and intents to invoke.
     ///
+    /// Defaults to [GamepadShortcuts.sequentialTraversal].
+    ///
+    /// If you need directional navigation consider either using
+    /// a [GamepadInterceptor] for local override or using
+    /// [GamepadShortcuts.directionalTraversal] for directional
+    /// focus navigation globally.
+    ///
     /// References of available intents can be found by looking up
     /// [WidgetsApp.defaultShortcuts], which contains the default keyboard
     /// shortcuts used in apps.
-    this.shortcuts = const {
-      GamepadActivatorButton.a(): ActivateIntent(),
-      GamepadActivatorButton.b(): DismissIntent(),
-      GamepadActivatorButton.dpadUp(): PreviousFocusIntent(),
-      GamepadActivatorButton.dpadLeft(): PreviousFocusIntent(),
-      GamepadActivatorButton.dpadDown(): NextFocusIntent(),
-      GamepadActivatorButton.dpadRight(): NextFocusIntent(),
-      GamepadActivatorAxis.rightStickUp(): ScrollIntent(
-        direction: AxisDirection.up,
-      ),
-      GamepadActivatorAxis.rightStickLeft(): ScrollIntent(
-        direction: AxisDirection.left,
-      ),
-      GamepadActivatorAxis.rightStickDown(): ScrollIntent(
-        direction: AxisDirection.down,
-      ),
-      GamepadActivatorAxis.rightStickRight(): ScrollIntent(
-        direction: AxisDirection.right,
-      ),
-    },
+    this.shortcuts = GamepadShortcuts.sequentialTraversal,
 
     /// Set of intents which will be repeated if a GamepadActivator
     /// linked to this Intent is being activated for

--- a/packages/flutter_gamepads/lib/src/gamepad_control.dart
+++ b/packages/flutter_gamepads/lib/src/gamepad_control.dart
@@ -217,7 +217,9 @@ class _GamepadControlState extends State<GamepadControl> {
     // Allow previous/next to use parent context when focusContext is null
     // to allow user to focus something even when there is no autofocus.
     return focusedContext ??
-        ((intent is PreviousFocusIntent || intent is NextFocusIntent)
+        ((intent is PreviousFocusIntent ||
+                intent is NextFocusIntent ||
+                intent is DirectionalFocusIntent)
             ? context
             : null);
   }


### PR DESCRIPTION
Adds `GamepadShortcuts.directionalTraversal` and `GamepadShortcuts.sequentialTraversal` as two bundled shortcut configurations that can be passed as `shortcuts` parameter to `GamepadControl`.

This PR also contains a fix so that DirectionalFocusIntent also uses the invoke context fallback mechanism that is used when PreviousFocusIntent or NextFocusIntent is invoked and there is no primaryFocus. This could in some rare cases be regarded as a breaking change, but I have opted to document it as a fix. 

If possible, this PR probably should not be squashed so that the fix also ends up in the package changelog. Let me know if I should re-write the commit messages/history in some way or move the fix to a separate (stacked) PR?